### PR TITLE
🧹 Remove commented out unused import in system_discovery context

### DIFF
--- a/src/codomyrmex/system_discovery/core/context.py
+++ b/src/codomyrmex/system_discovery/core/context.py
@@ -13,8 +13,6 @@ from codomyrmex.system_discovery.health.health_checker import HealthChecker
 
 from .discovery_engine import SystemDiscovery
 
-# from .capability_scanner import CapabilityScanner # Optional, might be heavy
-
 logger = get_logger(__name__)
 
 def get_system_context(root_dir: str = ".") -> dict[str, Any]:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a commented-out unused import in `src/codomyrmex/system_discovery/core/context.py`.
💡 **Why:** Commented-out code creates noise and reduces readability. Removing it improves the maintainability of the codebase.
✅ **Verification:** The change was verified by:
1. Running relevant unit tests in `src/codomyrmex/tests/unit/system_discovery/`. Test results remained consistent before and after the change (pre-existing failures due to environment issues were noted but not affected by this change).
2. Performing a syntax check using `py_compile`.
3. Manual review of the file content.
✨ **Result:** A cleaner and more readable `context.py` file without unnecessary commented-out code.

---
*PR created automatically by Jules for task [8685966828313044013](https://jules.google.com/task/8685966828313044013) started by @docxology*