### PR TITLE
feat: add MCP tools for IDE integration management

### DIFF
--- a/src/codomyrmex/ide/mcp_tools.py
+++ b/src/codomyrmex/ide/mcp_tools.py
@@ -28,6 +28,86 @@ def ide_get_active_file() -> dict:
 
 
 @mcp_tool(category="ide")
+def ide_list_integrations() -> dict:
+    """List available IDE integrations.
+
+    Returns the names of the supported IDE integrations that can be connected to.
+
+    Returns:
+        Dictionary with a list of available IDE integrations.
+    """
+    return {
+        "status": "success",
+        "integrations": ["antigravity", "cursor", "vscode"],
+    }
+
+
+def _get_client(integration: str):
+    """Helper to get the corresponding IDE client."""
+    if integration == "antigravity":
+        from codomyrmex.ide.antigravity.client import AntigravityClient
+
+        return AntigravityClient()
+    elif integration == "cursor":
+        from codomyrmex.ide.cursor import CursorClient
+
+        return CursorClient()
+    elif integration == "vscode":
+        from codomyrmex.ide.vscode import VSCodeClient
+
+        return VSCodeClient()
+    else:
+        raise ValueError(f"Unknown IDE integration: {integration}")
+
+
+@mcp_tool(category="ide")
+def ide_get_status(integration: str) -> dict:
+    """Get the connection status of a specified IDE integration.
+
+    Args:
+        integration: The name of the IDE integration ("antigravity", "cursor", "vscode").
+
+    Returns:
+        Dictionary with the connection status or error.
+    """
+    try:
+        client = _get_client(integration)
+        client.connect()
+        return {
+            "status": "success",
+            "integration": integration,
+            "connection_status": client.status.value,
+        }
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+
+
+@mcp_tool(category="ide")
+def ide_execute_command(integration: str, command: str, args: dict | None = None) -> dict:
+    """Execute an IDE command on a specified integration.
+
+    Args:
+        integration: The name of the IDE integration ("antigravity", "cursor", "vscode").
+        command: The command to execute.
+        args: Optional arguments for the command.
+
+    Returns:
+        Dictionary with the execution result or error.
+    """
+    try:
+        client = _get_client(integration)
+        client.connect()
+        result = client.execute_command_safe(command, args=args)
+        return {
+            "status": "success",
+            "integration": integration,
+            "result": result.to_dict(),
+        }
+    except Exception as e:
+        return {"status": "error", "message": str(e)}
+
+
+@mcp_tool(category="ide")
 def ide_list_tools() -> dict:
     """List all available Antigravity IDE tools.
 

--- a/src/codomyrmex/ide/mcp_tools.py
+++ b/src/codomyrmex/ide/mcp_tools.py
@@ -83,7 +83,9 @@ def ide_get_status(integration: str) -> dict:
 
 
 @mcp_tool(category="ide")
-def ide_execute_command(integration: str, command: str, args: dict | None = None) -> dict:
+def ide_execute_command(
+    integration: str, command: str, args: dict | None = None
+) -> dict:
     """Execute an IDE command on a specified integration.
 
     Args:

--- a/src/codomyrmex/tests/unit/ide/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/ide/test_mcp_tools.py
@@ -1,0 +1,62 @@
+"""Unit tests for IDE MCP tools."""
+
+import pytest
+
+from codomyrmex.ide.mcp_tools import (
+    ide_execute_command,
+    ide_get_status,
+    ide_list_integrations,
+)
+
+
+@pytest.mark.unit
+def test_ide_list_integrations():
+    """Test ide_list_integrations returns correct integrations."""
+    result = ide_list_integrations()
+    assert result["status"] == "success"
+    assert "integrations" in result
+    assert set(result["integrations"]) == {"antigravity", "cursor", "vscode"}
+
+
+@pytest.mark.unit
+def test_ide_get_status_valid_integration():
+    """Test ide_get_status with a valid integration."""
+    result = ide_get_status("antigravity")
+    assert result["status"] == "success"
+    assert result["integration"] == "antigravity"
+    assert "connection_status" in result
+    # We expect connecting or error if no real IDE is found,
+    # but the tool logic itself shouldn't raise unhandled exceptions
+    assert result["connection_status"] in ("connecting", "connected", "error", "disconnected")
+
+
+@pytest.mark.unit
+def test_ide_get_status_invalid_integration():
+    """Test ide_get_status handles invalid integration names gracefully."""
+    result = ide_get_status("invalid_ide")
+    assert result["status"] == "error"
+    assert "Unknown IDE integration: invalid_ide" in result["message"]
+
+
+@pytest.mark.unit
+def test_ide_execute_command_valid_integration():
+    """Test ide_execute_command with a valid integration and simple command."""
+    # Using 'antigravity' with a command that would fail safely if IDE not fully up
+    result = ide_execute_command("antigravity", "some_nonexistent_command")
+    assert result["status"] == "success"
+    assert result["integration"] == "antigravity"
+    assert "result" in result
+
+    # execute_command_safe should catch the error and return success=False in the IDECommandResult
+    command_result = result["result"]
+    assert "success" in command_result
+    # The actual success value will likely be False due to it being a dummy command/no IDE running
+    # but the MCP tool itself should return status="success" because it didn't crash
+
+
+@pytest.mark.unit
+def test_ide_execute_command_invalid_integration():
+    """Test ide_execute_command handles invalid integration names gracefully."""
+    result = ide_execute_command("invalid_ide", "test")
+    assert result["status"] == "error"
+    assert "Unknown IDE integration: invalid_ide" in result["message"]

--- a/src/codomyrmex/tests/unit/ide/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/ide/test_mcp_tools.py
@@ -27,7 +27,12 @@ def test_ide_get_status_valid_integration():
     assert "connection_status" in result
     # We expect connecting or error if no real IDE is found,
     # but the tool logic itself shouldn't raise unhandled exceptions
-    assert result["connection_status"] in ("connecting", "connected", "error", "disconnected")
+    assert result["connection_status"] in (
+        "connecting",
+        "connected",
+        "error",
+        "disconnected",
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
This PR introduces 3 new MCP tools to the `ide` module for listing integrations, checking status, and executing commands. It also includes comprehensive zero-mock unit tests to ensure their reliability.

---
*PR created automatically by Jules for task [7260150793022706479](https://jules.google.com/task/7260150793022706479) started by @docxology*