### PR TITLE
🧪 test: improve robustness of get_env tests using monkeypatch

### DIFF
--- a/src/codomyrmex/tests/unit/utils/test_utils_core.py
+++ b/src/codomyrmex/tests/unit/utils/test_utils_core.py
@@ -206,53 +206,46 @@ class TestTruncateString:
 class TestGetEnv:
     """Tests for get_env function."""
 
-    def test_existing_env_var(self):
+    def test_existing_env_var(self, monkeypatch):
         """Test getting existing environment variable."""
         from codomyrmex.utils import get_env
 
-        os.environ["TEST_VAR"] = "test_value"
-        try:
-            result = get_env("TEST_VAR")
-            assert result == "test_value"
-        finally:
-            del os.environ["TEST_VAR"]
+        monkeypatch.setenv("TEST_VAR", "test_value")
+        result = get_env("TEST_VAR")
+        assert result == "test_value"
 
-    def test_missing_env_var_with_default(self):
+    def test_missing_env_var_with_default(self, monkeypatch):
         """Test missing env var with default."""
         from codomyrmex.utils import get_env
 
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
         result = get_env("NONEXISTENT_VAR", default="default_value")
 
         assert result == "default_value"
 
-    def test_missing_required_env_var(self):
+    def test_missing_required_env_var(self, monkeypatch):
         """Test missing required env var raises error."""
         from codomyrmex.utils import get_env
 
+        monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
         with pytest.raises(ValueError):
             get_env("NONEXISTENT_VAR", required=True)
 
-    def test_existing_required_env_var(self):
+    def test_existing_required_env_var(self, monkeypatch):
         """Test existing required env var succeeds."""
         from codomyrmex.utils import get_env
 
-        os.environ["REQUIRED_VAR"] = "value"
-        try:
-            result = get_env("REQUIRED_VAR", required=True)
-            assert result == "value"
-        finally:
-            del os.environ["REQUIRED_VAR"]
+        monkeypatch.setenv("REQUIRED_VAR", "value")
+        result = get_env("REQUIRED_VAR", required=True)
+        assert result == "value"
 
-    def test_env_var_with_empty_value(self):
+    def test_env_var_with_empty_value(self, monkeypatch):
         """Test env var with empty value."""
         from codomyrmex.utils import get_env
 
-        os.environ["EMPTY_VAR"] = ""
-        try:
-            result = get_env("EMPTY_VAR", default="default")
-            assert result == ""  # Empty string is valid
-        finally:
-            del os.environ["EMPTY_VAR"]
+        monkeypatch.setenv("EMPTY_VAR", "")
+        result = get_env("EMPTY_VAR", default="default")
+        assert result == ""  # Empty string is valid
 
 
 @pytest.mark.unit

--- a/src/codomyrmex/tests/unit/utils/test_utils_core.py
+++ b/src/codomyrmex/tests/unit/utils/test_utils_core.py
@@ -1,7 +1,6 @@
 """Unit tests for core utility functions -- deep merge, retry, path resolution, directory creation, timestamps, and string truncation."""
 
 import argparse
-import os
 import time
 import unittest
 from pathlib import Path


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The tests for `get_env` manually manipulated `os.environ` which is considered an anti-pattern as it could leak global state and cause side effects in test runners if execution fails or when run in parallel. This changes them to use pytest's `monkeypatch` feature.

📊 **Coverage:** What scenarios are now tested
The exact same `get_env` scenarios are covered (existing variable, missing with default, missing required, existing required, empty string values), but they are executed safely.

✨ **Result:** The improvement in test coverage
Test quality, robustness, and hygiene improved significantly for the core utilities `__init__.py` module. Test isolation is now guaranteed for these environment variable tests.

---
*PR created automatically by Jules for task [1041312181806227331](https://jules.google.com/task/1041312181806227331) started by @docxology*