### PR TITLE
🔒 fix(auth): Resolve hardcoded secret vulnerability in TokenManager

### DIFF
--- a/src/codomyrmex/auth/tokens/token.py
+++ b/src/codomyrmex/auth/tokens/token.py
@@ -8,6 +8,7 @@ This module provides token functionality including:
 
 from __future__ import annotations
 
+import secrets
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -67,12 +68,14 @@ class TokenManager:
         Args:
             secret: Secret key for token signing
         """
-        self.secret = secret or "default_secret_change_in_production"
+        self.secret = secret or secrets.token_urlsafe(32)
         self.validator = TokenValidator(self.secret)
         self._tokens: dict[str, Token] = {}
         self._revoked_tokens: set[str] = set()
 
-    def create_token(self, user_id: str, permissions: list[str] | None = None, ttl: int = 3600) -> Token:
+    def create_token(
+        self, user_id: str, permissions: list[str] | None = None, ttl: int = 3600
+    ) -> Token:
         """Create a new authentication token.
 
         Args:


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability where `TokenManager` used a predictable hardcoded string `"default_secret_change_in_production"` as its fallback secret for signing and validating tokens.
⚠️ **Risk:** If a developer instantiates `TokenManager` without passing a secret, tokens would be signed using this universally known string. Attackers could trivially forge valid authentication tokens by signing them with this same string, leading to full authorization bypass and unauthorized access to protected resources.
🛡️ **Solution:** Replaced the hardcoded string with `secrets.token_urlsafe(32)`. Now, if a secret is not explicitly provided, a cryptographically secure, random 32-byte key is generated in memory for that runtime instance. This guarantees that tokens cannot be forged via a known default key while preserving functionality for testing and transient usage.

---
*PR created automatically by Jules for task [13273073320760428257](https://jules.google.com/task/13273073320760428257) started by @docxology*