### PR TITLE
feat(bio_simulation): enhance documentation and add MCP tools

### DIFF
--- a/src/codomyrmex/bio_simulation/AGENTS.md
+++ b/src/codomyrmex/bio_simulation/AGENTS.md
@@ -24,6 +24,8 @@ The Bio-Simulation module provides high-fidelity ant colony simulation. It is us
 
 6. **Safety**: Dead ants are automatically removed from `colony.ants` during `step()`.
 
+7. **MCP Tools**: Use `bio_simulation_run_colony` and `bio_simulation_evolve_population` exposed in `mcp_tools.py` for agentic interactions and retrieving stats/distributions easily via the MCP framework.
+
 ## Navigation
 
 - [README.md](README.md) | [SPEC.md](SPEC.md) | [PAI.md](PAI.md)

--- a/src/codomyrmex/bio_simulation/README.md
+++ b/src/codomyrmex/bio_simulation/README.md
@@ -12,14 +12,15 @@ High-fidelity biological simulation engine. Provides digital twins of ant coloni
 - **Agent State Machine**: High-fidelity behavioral states (FORAGING, RETURNING, RESTING).
 - **Spatial Environment**: Grid-based world with resources, obstacles, and pheromone dynamics.
 - **Genomics**: Trait-based genetic representation with mutation and crossover for evolutionary studies.
+- **MCP Tools**: Easy-to-use Model Context Protocol integration for controlling and analyzing simulations.
 
 ## PAI Integration
 
 | Algorithm Phase | Role | Tools Used |
 |----------------|------|-----------|
-| **THINK** | Run biological models to explore emergent behavior | Direct Python import |
+| **THINK** | Run biological models to explore emergent behavior | Direct Python import, `bio_simulation_run_colony` |
 | **BUILD** | Configure colony simulations and genomics parameters | Direct Python import |
-| **VERIFY** | Validate simulation outputs against expected distributions | Direct Python import |
+| **VERIFY** | Validate simulation outputs against expected distributions | Direct Python import, `bio_simulation_evolve_population` |
 
 ## Installation
 

--- a/src/codomyrmex/bio_simulation/SPEC.md
+++ b/src/codomyrmex/bio_simulation/SPEC.md
@@ -42,6 +42,13 @@ High-fidelity biological simulation engine for ant colony modeling, emergent beh
 - **perception**: Multiplier for food detection radius.
 - **endurance**: Multiplier for energy depletion rate and recovery.
 
+### MCP Tools
+
+| Tool | Signature | Description |
+|------|-----------|-------------|
+| `bio_simulation_run_colony` | `(population: int, hours: int) → dict` | Runs a colony simulation and returns stats. |
+| `bio_simulation_evolve_population` | `(generations: int, size: int) → dict` | Evolves a population and returns trait distributions. |
+
 ## Error Conditions
 
 - `ValueError`: If population or hours are negative.

--- a/src/codomyrmex/bio_simulation/mcp_tools.py
+++ b/src/codomyrmex/bio_simulation/mcp_tools.py
@@ -1,0 +1,64 @@
+"""MCP tools for the bio_simulation module.
+
+Exposes tools for running colony simulations and evolving
+populations via genetic algorithms.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from codomyrmex.model_context_protocol.decorators import mcp_tool
+
+
+@mcp_tool(
+    category="bio_simulation",
+    description=(
+        "Run an ant colony simulation for a specified number of hours "
+        "and return a statistical summary of the colony's final state."
+    ),
+)
+def bio_simulation_run_colony(population: int, hours: int) -> dict[str, Any]:
+    """Run a colony simulation and return its final statistics.
+
+    Args:
+        population: Number of ants to simulate.
+        hours: Number of hours to simulate.
+
+    Returns:
+        A dictionary containing the simulation statistics.
+    """
+    from codomyrmex.bio_simulation import Colony
+
+    colony = Colony(population=population)
+    colony.step(hours=hours)
+    return colony.stats()
+
+
+@mcp_tool(
+    category="bio_simulation",
+    description=(
+        "Evolve a population of genomes for a specified number of generations "
+        "and return the final trait distribution."
+    ),
+)
+def bio_simulation_evolve_population(
+    generations: int, size: int
+) -> dict[str, dict[str, float]]:
+    """Evolve a population and return trait distributions.
+
+    Args:
+        generations: Number of generations to evolve.
+        size: Size of the population.
+
+    Returns:
+        A dictionary mapping traits to their statistical distributions.
+    """
+    from codomyrmex.bio_simulation import Genome, Population
+
+    # Initialize a population with random genomes
+    genomes = [Genome.random() for _ in range(size)]
+    population = Population(genomes=genomes)
+    population.evolve(generations=generations)
+
+    return population.trait_distribution()

--- a/src/codomyrmex/bio_simulation/visualization.py
+++ b/src/codomyrmex/bio_simulation/visualization.py
@@ -4,8 +4,13 @@ from .colony import Colony
 
 
 def render_colony_state(colony: Colony) -> ScatterPlot:
-    """
-    Renders a scatter plot of current ant positions.
+    """Renders a scatter plot of current ant positions.
+
+    Args:
+        colony: The colony to visualize.
+
+    Returns:
+        A ScatterPlot of the colony state.
     """
     # Assuming ants have x and y attributes
     # If not, use mock data or fix based on Colony implementation

--- a/src/codomyrmex/tests/unit/bio_simulation/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/bio_simulation/test_mcp_tools.py
@@ -1,0 +1,45 @@
+"""Strictly zero-mock tests for bio_simulation MCP tools."""
+
+import pytest
+
+from codomyrmex.bio_simulation.mcp_tools import (
+    bio_simulation_evolve_population,
+    bio_simulation_run_colony,
+)
+
+
+@pytest.mark.unit
+def test_bio_simulation_run_colony() -> None:
+    """Testing running an ant colony simulation via the MCP tool."""
+    stats = bio_simulation_run_colony(population=10, hours=1)
+
+    assert isinstance(stats, dict)
+    assert "tick" in stats
+    assert "alive" in stats
+    assert "dead" in stats
+    assert "food_collected" in stats
+
+    assert stats["tick"] == 60  # 1 hour = 60 ticks
+    assert stats["alive"] + stats["dead"] == 10  # Population constraint
+
+
+@pytest.mark.unit
+def test_bio_simulation_evolve_population() -> None:
+    """Testing evolving a population via the MCP tool."""
+    traits_dist = bio_simulation_evolve_population(generations=5, size=20)
+
+    assert isinstance(traits_dist, dict)
+
+    expected_traits = {"speed", "strength", "perception", "endurance"}
+    for trait in expected_traits:
+        assert trait in traits_dist
+
+        trait_stats = traits_dist[trait]
+        assert "mean" in trait_stats
+        assert "std" in trait_stats
+        assert "min" in trait_stats
+        assert "max" in trait_stats
+
+        # Verify basic range sanity checks for genomes created with random values
+        assert 0.0 <= trait_stats["min"] <= trait_stats["max"] <= 1.0
+        assert 0.0 <= trait_stats["mean"] <= 1.0


### PR DESCRIPTION
This PR addresses the missing docstrings in the `bio_simulation` module, specifically for the `render_colony_state` function. It also expands the module's capabilities by introducing an `mcp_tools.py` file, similar to other modules, which registers `@mcp_tool` endpoints for running colony simulations (`bio_simulation_run_colony`) and evolving genome populations (`bio_simulation_evolve_population`). Strictly zero-mock unit tests have been added to verify these tools without stubbing dependencies. Documentation files have been updated to reflect these additions.

---
*PR created automatically by Jules for task [9351518452923671529](https://jules.google.com/task/9351518452923671529) started by @docxology*