### PR TITLE
Add mcp tools, unit tests, and fix docstrings in config_monitoring

### DIFF
--- a/src/codomyrmex/config_monitoring/config_monitor.py
+++ b/src/codomyrmex/config_monitoring/config_monitor.py
@@ -1,3 +1,9 @@
+"""Configuration monitoring module for Codomyrmex.
+
+Provides classes and functions to detect changes, audit configurations,
+and manage configuration snapshots.
+"""
+
 import hashlib
 import json
 import re
@@ -14,9 +20,11 @@ from codomyrmex.logging_monitoring.core.logger_config import get_logger
 
 logger = get_logger(__name__)
 
+
 @dataclass
 class ConfigChange:
     """Configuration change record."""
+
     change_id: str
     config_path: str
     change_type: str  # "created", "modified", "deleted"
@@ -29,6 +37,7 @@ class ConfigChange:
 @dataclass
 class ConfigAudit:
     """Configuration audit record."""
+
     audit_id: str
     timestamp: datetime
     environment: str
@@ -40,6 +49,7 @@ class ConfigAudit:
 @dataclass
 class ConfigSnapshot:
     """Configuration snapshot for drift detection."""
+
     snapshot_id: str
     timestamp: datetime
     environment: str
@@ -54,6 +64,7 @@ class ConfigurationMonitor:
 
         Args:
             workspace_dir: Workspace directory for monitoring data
+
         """
         self.workspace_dir = Path(workspace_dir) if workspace_dir else Path.cwd()
         self.monitoring_dir = self.workspace_dir / "config_monitoring"
@@ -119,6 +130,7 @@ class ConfigurationMonitor:
 
         Returns:
             SHA-256 hash or empty string if file doesn't exist
+
         """
         path = Path(file_path)
         if not path.is_file():
@@ -149,6 +161,7 @@ class ConfigurationMonitor:
 
         Returns:
             The recorded ConfigChange
+
         """
         change_id = f"chg_{int(time.time() * 1000)}"
         change = ConfigChange(
@@ -173,6 +186,7 @@ class ConfigurationMonitor:
 
         Returns:
             List of detected changes
+
         """
         changes = []
         new_hashes = {}
@@ -261,6 +275,7 @@ class ConfigurationMonitor:
 
         Returns:
             Created snapshot
+
         """
         path = Path(config_dir)
         if not path.is_dir():
@@ -304,6 +319,7 @@ class ConfigurationMonitor:
 
         Returns:
             Drift analysis report
+
         """
         if snapshot_id not in self._snapshots:
             # Try reloading from disk just in case
@@ -369,6 +385,7 @@ class ConfigurationMonitor:
 
         Returns:
             ConfigAudit record
+
         """
         path = Path(config_dir)
         if not path.is_dir():
@@ -445,6 +462,7 @@ class ConfigurationMonitor:
 
         Returns:
             List of changes
+
         """
         if config_path:
             abs_path = str(Path(config_path).absolute())

--- a/src/codomyrmex/config_monitoring/mcp_tools.py
+++ b/src/codomyrmex/config_monitoring/mcp_tools.py
@@ -1,0 +1,108 @@
+"""MCP tools for configuration monitoring."""
+
+from typing import Any
+
+from codomyrmex.model_context_protocol.decorators import mcp_tool
+
+from .config_monitor import ConfigurationMonitor
+
+
+@mcp_tool(category="config_monitoring")
+def config_monitoring_detect_changes(
+    config_paths: list[str], workspace_dir: str | None = None
+) -> list[dict[str, Any]]:
+    """Detect changes in configuration files.
+
+    Args:
+        config_paths: List of configuration file paths to monitor.
+        workspace_dir: Optional workspace directory.
+
+    Returns:
+        List of configuration changes detected.
+
+    """
+    monitor = ConfigurationMonitor(workspace_dir)
+    # Type cast needed because detect_config_changes expects list[str | Path]
+    changes = monitor.detect_config_changes(list(config_paths))
+    return [
+        {
+            "change_id": c.change_id,
+            "config_path": c.config_path,
+            "change_type": c.change_type,
+            "timestamp": c.timestamp.isoformat(),
+            "previous_hash": c.previous_hash,
+            "current_hash": c.current_hash,
+        }
+        for c in changes
+    ]
+
+
+@mcp_tool(category="config_monitoring")
+def config_monitoring_create_snapshot(
+    environment: str, config_dir: str, workspace_dir: str | None = None
+) -> dict[str, Any]:
+    """Create a configuration snapshot.
+
+    Args:
+        environment: Environment name.
+        config_dir: Directory containing configuration files.
+        workspace_dir: Optional workspace directory.
+
+    Returns:
+        The created configuration snapshot.
+
+    """
+    monitor = ConfigurationMonitor(workspace_dir)
+    snapshot = monitor.create_snapshot(environment, config_dir)
+    return {
+        "snapshot_id": snapshot.snapshot_id,
+        "timestamp": snapshot.timestamp.isoformat(),
+        "environment": snapshot.environment,
+        "total_files": snapshot.total_files,
+    }
+
+
+@mcp_tool(category="config_monitoring")
+def config_monitoring_detect_drift(
+    snapshot_id: str, config_dir: str, workspace_dir: str | None = None
+) -> dict[str, Any]:
+    """Detect drift between a snapshot and the current configuration directory.
+
+    Args:
+        snapshot_id: ID of the snapshot to compare against.
+        config_dir: Current configuration directory to compare.
+        workspace_dir: Optional workspace directory.
+
+    Returns:
+        Drift analysis report.
+
+    """
+    monitor = ConfigurationMonitor(workspace_dir)
+    return monitor.detect_drift(snapshot_id, config_dir)
+
+
+@mcp_tool(category="config_monitoring")
+def config_monitoring_audit(
+    environment: str, config_dir: str, workspace_dir: str | None = None
+) -> dict[str, Any]:
+    """Perform a compliance audit on configuration files.
+
+    Args:
+        environment: Environment name.
+        config_dir: Directory to audit.
+        workspace_dir: Optional workspace directory.
+
+    Returns:
+        Audit results including compliance status and issues found.
+
+    """
+    monitor = ConfigurationMonitor(workspace_dir)
+    audit = monitor.audit_configuration(environment, config_dir)
+    return {
+        "audit_id": audit.audit_id,
+        "timestamp": audit.timestamp.isoformat(),
+        "environment": audit.environment,
+        "compliance_status": audit.compliance_status,
+        "issues_found": audit.issues_found,
+        "recommendations": audit.recommendations,
+    }

--- a/src/codomyrmex/config_monitoring/watcher.py
+++ b/src/codomyrmex/config_monitoring/watcher.py
@@ -18,6 +18,7 @@ class ConfigWatcher:
             file_path: Path to the file to watch
             callback: Function to call when change is detected
             interval: Polling interval in seconds
+
         """
         self.file_path = Path(file_path).absolute()
         self.callback = callback
@@ -61,7 +62,7 @@ class ConfigWatcher:
                 logger.info(f"Stopped watching {self.file_path}")
 
     def _run(self) -> None:
-        """Polling loop."""
+        """Run the polling loop to check for file changes."""
         while not self._stop_event.is_set():
             try:
                 current_mtime = self._get_mtime()

--- a/src/codomyrmex/tests/unit/config_monitoring/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/config_monitoring/test_mcp_tools.py
@@ -1,0 +1,73 @@
+"""Unit tests for config_monitoring MCP tools."""
+
+from pathlib import Path
+
+import pytest
+
+from codomyrmex.config_monitoring.mcp_tools import (
+    config_monitoring_audit,
+    config_monitoring_create_snapshot,
+    config_monitoring_detect_changes,
+    config_monitoring_detect_drift,
+)
+
+
+@pytest.fixture
+def workspace_dir(tmp_path: Path) -> Path:
+    return tmp_path / "workspace"
+
+
+@pytest.fixture
+def config_dir(workspace_dir: Path) -> Path:
+    config = workspace_dir / "config"
+    config.mkdir(parents=True)
+    return config
+
+
+@pytest.mark.unit
+def test_mcp_detect_changes(workspace_dir: Path, config_dir: Path) -> None:
+    config_file = config_dir / "app.yaml"
+    config_file.write_text("key: value")
+
+    changes = config_monitoring_detect_changes([str(config_file)], str(workspace_dir))
+    assert len(changes) == 1
+    assert changes[0]["change_type"] == "created"
+
+    config_file.write_text("key: new_value")
+    changes2 = config_monitoring_detect_changes([str(config_file)], str(workspace_dir))
+    assert len(changes2) == 1
+    assert changes2[0]["change_type"] == "modified"
+
+
+@pytest.mark.unit
+def test_mcp_create_snapshot_and_drift(workspace_dir: Path, config_dir: Path) -> None:
+    config_file = config_dir / "app.yaml"
+    config_file.write_text("key: value")
+
+    snapshot = config_monitoring_create_snapshot(
+        "prod", str(config_dir), str(workspace_dir)
+    )
+    assert snapshot["environment"] == "prod"
+    assert snapshot["total_files"] == 1
+
+    drift = config_monitoring_detect_drift(
+        snapshot["snapshot_id"], str(config_dir), str(workspace_dir)
+    )
+    assert drift["drift_detected"] is False
+
+    config_file.write_text("key: new_value")
+    drift_after = config_monitoring_detect_drift(
+        snapshot["snapshot_id"], str(config_dir), str(workspace_dir)
+    )
+    assert drift_after["drift_detected"] is True
+
+
+@pytest.mark.unit
+def test_mcp_audit(workspace_dir: Path, config_dir: Path) -> None:
+    secret_file = config_dir / "secrets.yaml"
+    secret_file.write_text("password: 'supersecret'")
+
+    audit = config_monitoring_audit("prod", str(config_dir), str(workspace_dir))
+    assert audit["environment"] == "prod"
+    assert audit["compliance_status"] == "non_compliant"
+    assert len(audit["issues_found"]) > 0


### PR DESCRIPTION
Resolves an issue regarding the `config_monitoring` module to add `mcp_tools.py`, fix docstrings, write zero-mock tests, and verify documentation exists using `uv`.

---
*PR created automatically by Jules for task [2860782919605881249](https://jules.google.com/task/2860782919605881249) started by @docxology*