### PR TITLE
Enhance Feature Store with MCP Tools and Documentation

### DIFF
--- a/src/codomyrmex/feature_store/AGENTS.md
+++ b/src/codomyrmex/feature_store/AGENTS.md
@@ -21,6 +21,7 @@ Feature store module for ML inference and training pipelines. Provides typed fea
 | `service.py` | `FeatureTransform` | Registers per-feature callables; `apply()` transforms a `FeatureVector` immutably |
 | `service.py` | `FeatureService` | High-level facade: group registration, single/batch ingestion, transform-aware retrieval |
 | `exceptions.py` | `FeatureStoreError` | Module-specific exception hierarchy. |
+| `mcp_tools.py` | `get_mcp_tools` | Provides Model Context Protocol tools for registering, ingesting, and retrieving features. |
 
 ## Operating Contracts
 

--- a/src/codomyrmex/feature_store/README.md
+++ b/src/codomyrmex/feature_store/README.md
@@ -109,6 +109,14 @@ def get_group_features(self, entity_id: str, group_name: str) -> FeatureVector
 def list_groups(self) -> List[str]
 ```
 
+## MCP Tools
+
+The feature store module exposes tools for the Model Context Protocol (MCP) to manage features directly from agents:
+
+- `feature_store_register_feature`: Registers a new feature definition in the store.
+- `feature_store_ingest`: Ingests feature values for a specific entity.
+- `feature_store_get_features`: Retrieves feature values for an entity.
+
 ## Exceptions
 
 | Exception | Description |

--- a/src/codomyrmex/feature_store/SPEC.md
+++ b/src/codomyrmex/feature_store/SPEC.md
@@ -50,6 +50,13 @@ Three-layer design: **models** (dataclasses and enums), **store** (abstract back
 | `add` | `feature_name, func` | `FeatureTransform` | Register a transform callable (chainable) |
 | `apply` | `vector: FeatureVector` | `FeatureVector` | Apply transforms, returning new vector |
 
+### MCP Tools
+
+The `mcp_tools.py` module exposes tools for integrating the Feature Store via the Model Context Protocol:
+- `feature_store_register_feature`: Register new definitions dynamically.
+- `feature_store_ingest`: Store entity feature values.
+- `feature_store_get_features`: Retrieve computed feature vectors for an entity.
+
 ## Exceptions
 
 - `FeatureStoreError`: Base exception for feature store operations.

--- a/src/codomyrmex/feature_store/__init__.py
+++ b/src/codomyrmex/feature_store/__init__.py
@@ -39,6 +39,7 @@ except ImportError:
 
 def cli_commands():
     """Return CLI commands for the feature_store module."""
+
     def _list_features():
         print(
             "Feature Store\n"

--- a/src/codomyrmex/feature_store/exceptions.py
+++ b/src/codomyrmex/feature_store/exceptions.py
@@ -7,16 +7,23 @@ from codomyrmex.exceptions.base import CodomyrmexError
 
 class FeatureStoreError(CodomyrmexError):
     """Base exception for feature store operations."""
+
     pass
+
 
 class FeatureNotFoundError(FeatureStoreError):
     """Raised when a feature definition or value is not found."""
+
     pass
+
 
 class FeatureRegistrationError(FeatureStoreError):
     """Raised when feature registration fails."""
+
     pass
+
 
 class FeatureValidationError(FeatureStoreError):
     """Raised when feature value validation fails."""
+
     pass

--- a/src/codomyrmex/feature_store/mcp_tools.py
+++ b/src/codomyrmex/feature_store/mcp_tools.py
@@ -1,0 +1,139 @@
+"""
+MCP Tools for Feature Store.
+
+Provides Model Context Protocol tools for feature store operations.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from codomyrmex.model_context_protocol.decorators import mcp_tool
+
+from .models import FeatureDefinition, FeatureType, ValueType
+from .service import FeatureService
+from .store import InMemoryFeatureStore
+
+# Global singleton service for MCP tool persistence within the process
+_STORE = InMemoryFeatureStore()
+_SERVICE = FeatureService(store=_STORE)
+
+
+def _get_feature_type(type_str: str) -> FeatureType:
+    try:
+        return FeatureType(type_str.lower())
+    except ValueError as e:
+        valid = [t.value for t in FeatureType]
+        raise ValueError(
+            f"Invalid feature type '{type_str}'. Must be one of {valid}"
+        ) from e
+
+
+def _get_value_type(type_str: str) -> ValueType:
+    try:
+        return ValueType(type_str.lower())
+    except ValueError as e:
+        valid = [t.value for t in ValueType]
+        raise ValueError(
+            f"Invalid value type '{type_str}'. Must be one of {valid}"
+        ) from e
+
+
+@mcp_tool(
+    name="feature_store_register_feature",
+    description="Register a new feature definition in the feature store.",
+)
+def feature_store_register_feature(
+    name: str,
+    feature_type: str,
+    value_type: str,
+    description: str = "",
+    default_value: Any = None,
+    tags: list[str] | None = None,
+) -> dict[str, Any]:
+    """
+    Register a new feature definition in the feature store.
+
+    Args:
+        name: The name of the feature.
+        feature_type: Type of feature (numeric, categorical, embedding, text, timestamp, boolean).
+        value_type: Type of the feature value (int, float, string, bool, list, dict).
+        description: A brief description of the feature.
+        default_value: Optional default value.
+        tags: Optional list of tags.
+    """
+    ft = _get_feature_type(feature_type)
+    vt = _get_value_type(value_type)
+
+    definition = FeatureDefinition(
+        name=name,
+        feature_type=ft,
+        value_type=vt,
+        description=description,
+        default_value=default_value,
+        tags=tags or [],
+    )
+    _SERVICE.register_feature(definition)
+
+    return {
+        "status": "success",
+        "message": f"Feature '{name}' registered successfully.",
+        "definition": definition.to_dict(),
+    }
+
+
+@mcp_tool(
+    name="feature_store_ingest",
+    description="Ingest feature values for a specific entity into the feature store.",
+)
+def feature_store_ingest(
+    entity_id: str,
+    features: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Ingest feature values for a specific entity into the feature store.
+
+    Args:
+        entity_id: The ID of the entity (e.g., user_123).
+        features: A dictionary mapping feature names to their values.
+    """
+    _SERVICE.ingest(features=features, entity_id=entity_id)
+    return {
+        "status": "success",
+        "message": f"Successfully ingested features for entity '{entity_id}'.",
+        "features": features,
+    }
+
+
+@mcp_tool(
+    name="feature_store_get_features",
+    description="Retrieve feature values for an entity from the feature store.",
+)
+def feature_store_get_features(
+    entity_id: str,
+    feature_names: list[str],
+) -> dict[str, Any]:
+    """
+    Retrieve feature values for an entity from the feature store.
+
+    Args:
+        entity_id: The ID of the entity.
+        feature_names: A list of feature names to retrieve.
+    """
+    vector = _SERVICE.get_features(
+        entity_id=entity_id, feature_names=feature_names, apply_transform=True
+    )
+    return {
+        "status": "success",
+        "entity_id": vector.entity_id,
+        "features": vector.features,
+        "timestamp": vector.timestamp.isoformat(),
+    }
+
+
+def get_mcp_tools() -> list[Callable[..., Any]]:
+    """Return a list of all MCP tools defined in this module."""
+    return [
+        feature_store_register_feature,
+        feature_store_ingest,
+        feature_store_get_features,
+    ]

--- a/src/codomyrmex/feature_store/models.py
+++ b/src/codomyrmex/feature_store/models.py
@@ -12,6 +12,7 @@ from typing import Any
 
 class FeatureType(Enum):
     """Types of features."""
+
     NUMERIC = "numeric"
     CATEGORICAL = "categorical"
     EMBEDDING = "embedding"
@@ -22,6 +23,7 @@ class FeatureType(Enum):
 
 class ValueType(Enum):
     """Data types for feature values."""
+
     INT = "int"
     FLOAT = "float"
     STRING = "string"
@@ -33,6 +35,7 @@ class ValueType(Enum):
 @dataclass
 class FeatureDefinition:
     """Definition of a feature."""
+
     name: str
     feature_type: FeatureType
     value_type: ValueType
@@ -82,6 +85,7 @@ class FeatureDefinition:
 @dataclass
 class FeatureValue:
     """A feature value with metadata."""
+
     feature_name: str
     entity_id: str
     value: Any
@@ -97,6 +101,7 @@ class FeatureValue:
 @dataclass
 class FeatureVector:
     """A collection of feature values for an entity."""
+
     entity_id: str
     features: dict[str, Any]
     timestamp: datetime = field(default_factory=datetime.now)
@@ -114,6 +119,7 @@ class FeatureVector:
 @dataclass
 class FeatureGroup:
     """A group of related features."""
+
     name: str
     features: list[FeatureDefinition]
     description: str = ""

--- a/src/codomyrmex/feature_store/service.py
+++ b/src/codomyrmex/feature_store/service.py
@@ -28,6 +28,7 @@ class FeatureTransform:
     """
 
     def __init__(self):
+        """Initialize a new FeatureTransform instance."""
         self._transforms: dict[str, Callable[[Any], Any]] = {}
 
     def add(self, feature_name: str, func: Callable[[Any], Any]) -> "FeatureTransform":
@@ -85,6 +86,13 @@ class FeatureService:
         store: FeatureStore | None = None,
         transform: FeatureTransform | None = None,
     ):
+        """
+        Initialize the FeatureService.
+
+        Args:
+            store: An optional FeatureStore instance. Defaults to InMemoryFeatureStore.
+            transform: An optional FeatureTransform instance to apply during retrieval.
+        """
         self.store = store or InMemoryFeatureStore()
         self.transform = transform
         self._groups: dict[str, FeatureGroup] = {}
@@ -109,7 +117,9 @@ class FeatureService:
             try:
                 self.store.set_value(name, entity_id, value)
             except FeatureStoreError as e:
-                logger.error(f"Error ingesting feature '{name}' for entity '{entity_id}': {e}")
+                logger.error(
+                    f"Error ingesting feature '{name}' for entity '{entity_id}': {e}"
+                )
                 raise
 
     def ingest_batch(
@@ -127,7 +137,9 @@ class FeatureService:
                     self.ingest(features, entity_id)
                     count += 1
                 except FeatureStoreError as e:
-                    logger.warning(f"Skipping record for entity '{entity_id}' due to error: {e}")
+                    logger.warning(
+                        f"Skipping record for entity '{entity_id}' due to error: {e}"
+                    )
             else:
                 logger.warning(f"Skipping record: missing '{entity_id_field}' field")
         return count

--- a/src/codomyrmex/feature_store/store.py
+++ b/src/codomyrmex/feature_store/store.py
@@ -78,8 +78,11 @@ class InMemoryFeatureStore(FeatureStore):
     """
 
     def __init__(self):
+        """Initialize a new InMemoryFeatureStore instance."""
         self._definitions: dict[str, FeatureDefinition] = {}
-        self._values: dict[str, dict[str, FeatureValue]] = {}  # feature_name -> entity_id -> value
+        self._values: dict[
+            str, dict[str, FeatureValue]
+        ] = {}  # feature_name -> entity_id -> value
         self._lock = threading.Lock()
 
     def register_feature(self, definition: FeatureDefinition) -> None:
@@ -93,7 +96,9 @@ class InMemoryFeatureStore(FeatureStore):
             FeatureRegistrationError: If definition is invalid.
         """
         if not definition or not definition.name:
-            raise FeatureRegistrationError("Invalid feature definition: name is required")
+            raise FeatureRegistrationError(
+                "Invalid feature definition: name is required"
+            )
 
         with self._lock:
             self._definitions[definition.name] = definition

--- a/src/codomyrmex/tests/unit/feature_store/test_feature_store.py
+++ b/src/codomyrmex/tests/unit/feature_store/test_feature_store.py
@@ -1,4 +1,5 @@
 """Unit tests for feature_store module."""
+
 import pytest
 
 from codomyrmex.feature_store import (
@@ -24,11 +25,13 @@ class TestFeatureStoreImports:
     def test_module_imports(self):
         """Verify module can be imported without errors."""
         import codomyrmex.feature_store as feature_store
+
         assert feature_store is not None
 
     def test_public_api_exists(self):
         """Verify expected public API is available."""
         from codomyrmex.feature_store import __all__
+
         expected_exports = [
             "FeatureType",
             "ValueType",
@@ -255,12 +258,18 @@ class TestInMemoryFeatureStore:
         """Verify invalid registration raises error."""
         store = InMemoryFeatureStore()
         with pytest.raises(FeatureRegistrationError):
-            store.register_feature(FeatureDefinition(name="", feature_type=FeatureType.TEXT, value_type=ValueType.STRING))
+            store.register_feature(
+                FeatureDefinition(
+                    name="", feature_type=FeatureType.TEXT, value_type=ValueType.STRING
+                )
+            )
 
     def test_store_set_and_get_value(self):
         """Verify value storage and retrieval."""
         store = InMemoryFeatureStore()
-        store.register_feature(FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT))
+        store.register_feature(
+            FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT)
+        )
 
         store.set_value("score", "entity_1", 0.95)
         value = store.get_value("score", "entity_1")
@@ -278,14 +287,18 @@ class TestInMemoryFeatureStore:
     def test_store_set_invalid_type(self):
         """Verify setting invalid type raises error."""
         store = InMemoryFeatureStore()
-        store.register_feature(FeatureDefinition("age", FeatureType.NUMERIC, ValueType.INT))
+        store.register_feature(
+            FeatureDefinition("age", FeatureType.NUMERIC, ValueType.INT)
+        )
         with pytest.raises(FeatureValidationError):
             store.set_value("age", "entity_1", "twenty-five")
 
     def test_store_value_versioning(self):
         """Verify value versioning on updates."""
         store = InMemoryFeatureStore()
-        store.register_feature(FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT))
+        store.register_feature(
+            FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT)
+        )
 
         store.set_value("score", "entity_1", 0.8)
         store.set_value("score", "entity_1", 0.9)
@@ -297,8 +310,14 @@ class TestInMemoryFeatureStore:
     def test_store_get_vector(self):
         """Verify vector retrieval."""
         store = InMemoryFeatureStore()
-        store.register_feature(FeatureDefinition("age", FeatureType.NUMERIC, ValueType.INT, default_value=0))
-        store.register_feature(FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT))
+        store.register_feature(
+            FeatureDefinition(
+                "age", FeatureType.NUMERIC, ValueType.INT, default_value=0
+            )
+        )
+        store.register_feature(
+            FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT)
+        )
 
         store.set_value("age", "user_1", 25)
         store.set_value("score", "user_1", 0.95)
@@ -313,7 +332,9 @@ class TestInMemoryFeatureStore:
     def test_store_delete_value(self):
         """Verify value deletion."""
         store = InMemoryFeatureStore()
-        store.register_feature(FeatureDefinition("test", FeatureType.NUMERIC, ValueType.INT))
+        store.register_feature(
+            FeatureDefinition("test", FeatureType.NUMERIC, ValueType.INT)
+        )
 
         store.set_value("test", "entity_1", 100)
         deleted = store.delete_value("test", "entity_1")
@@ -346,6 +367,7 @@ class TestFeatureTransform:
     def test_transform_error_handling(self):
         """Verify transform errors are handled gracefully."""
         transform = FeatureTransform()
+
         def failing_transform(v):
             raise ValueError("Failed")
 
@@ -364,11 +386,13 @@ class TestFeatureService:
         """Verify feature registration and ingestion."""
         service = FeatureService()
 
-        service.register_feature(FeatureDefinition(
-            name="rating",
-            feature_type=FeatureType.NUMERIC,
-            value_type=ValueType.FLOAT,
-        ))
+        service.register_feature(
+            FeatureDefinition(
+                name="rating",
+                feature_type=FeatureType.NUMERIC,
+                value_type=ValueType.FLOAT,
+            )
+        )
 
         service.ingest({"rating": 4.5}, entity_id="item_123")
 
@@ -394,14 +418,16 @@ class TestFeatureService:
     def test_service_ingest_batch(self):
         """Verify batch ingestion."""
         service = FeatureService()
-        service.register_feature(FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT))
+        service.register_feature(
+            FeatureDefinition("score", FeatureType.NUMERIC, ValueType.FLOAT)
+        )
 
         batch = [
             {"entity_id": "user_1", "score": 0.8},
             {"entity_id": "user_2", "score": 0.9},
             {"entity_id": "user_3", "score": 0.7},
             {"score": 0.5},  # Missing entity_id
-            {"entity_id": "user_4", "score": "invalid"}, # Invalid type
+            {"entity_id": "user_4", "score": "invalid"},  # Invalid type
         ]
 
         count = service.ingest_batch(batch)
@@ -415,7 +441,7 @@ class TestFeatureService:
         service = FeatureService()
         group = FeatureGroup(
             name="g1",
-            features=[FeatureDefinition("f1", FeatureType.NUMERIC, ValueType.INT)]
+            features=[FeatureDefinition("f1", FeatureType.NUMERIC, ValueType.INT)],
         )
         service.register_group(group)
         service.ingest({"f1": 10}, "e1")

--- a/src/codomyrmex/tests/unit/feature_store/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/feature_store/test_mcp_tools.py
@@ -1,0 +1,115 @@
+"""Unit tests for feature_store MCP tools."""
+
+import pytest
+
+from codomyrmex.feature_store.mcp_tools import (
+    feature_store_get_features,
+    feature_store_ingest,
+    feature_store_register_feature,
+    get_mcp_tools,
+)
+
+
+@pytest.mark.unit
+def test_get_mcp_tools():
+    """Verify get_mcp_tools returns expected tools."""
+    tools = get_mcp_tools()
+    assert isinstance(tools, list)
+    assert len(tools) == 3
+    assert feature_store_register_feature in tools
+    assert feature_store_ingest in tools
+    assert feature_store_get_features in tools
+
+
+@pytest.mark.unit
+def test_feature_store_register_feature():
+    """Verify feature_store_register_feature registers a feature definition."""
+    result = feature_store_register_feature(
+        name="test_user_age",
+        feature_type="numeric",
+        value_type="int",
+        description="User age in years",
+        default_value=0,
+    )
+
+    assert result["status"] == "success"
+    assert "test_user_age" in result["message"]
+
+    definition = result["definition"]
+    assert definition["name"] == "test_user_age"
+    assert definition["feature_type"] == "numeric"
+    assert definition["value_type"] == "int"
+    assert definition["description"] == "User age in years"
+    assert definition["default_value"] == 0
+
+
+@pytest.mark.unit
+def test_feature_store_register_feature_invalid_type():
+    """Verify feature_store_register_feature raises error for invalid types."""
+    with pytest.raises(ValueError, match="Invalid feature type"):
+        feature_store_register_feature(
+            name="test_invalid",
+            feature_type="invalid_type",
+            value_type="int",
+        )
+
+    with pytest.raises(ValueError, match="Invalid value type"):
+        feature_store_register_feature(
+            name="test_invalid",
+            feature_type="numeric",
+            value_type="invalid_type",
+        )
+
+
+@pytest.mark.unit
+def test_feature_store_ingest_and_get():
+    """Verify feature_store_ingest stores values and feature_store_get_features retrieves them."""
+    # Register features
+    feature_store_register_feature(
+        name="user_score",
+        feature_type="numeric",
+        value_type="float",
+        default_value=0.0,
+    )
+    feature_store_register_feature(
+        name="user_role",
+        feature_type="categorical",
+        value_type="string",
+    )
+
+    # Ingest features
+    ingest_result = feature_store_ingest(
+        entity_id="user_999",
+        features={
+            "user_score": 95.5,
+            "user_role": "admin",
+        },
+    )
+
+    assert ingest_result["status"] == "success"
+    assert ingest_result["features"] == {"user_score": 95.5, "user_role": "admin"}
+
+    # Get features
+    get_result = feature_store_get_features(
+        entity_id="user_999",
+        feature_names=["user_score", "user_role", "user_unknown"],
+    )
+
+    assert get_result["status"] == "success"
+    assert get_result["entity_id"] == "user_999"
+    assert get_result["features"]["user_score"] == 95.5
+    assert get_result["features"]["user_role"] == "admin"
+    assert get_result["features"].get("user_unknown") is None
+    assert "timestamp" in get_result
+
+
+@pytest.mark.unit
+def test_feature_store_ingest_invalid():
+    """Verify feature_store_ingest handles errors when ingesting invalid features."""
+    from codomyrmex.feature_store.exceptions import FeatureNotFoundError
+
+    with pytest.raises(FeatureNotFoundError):
+        feature_store_ingest(
+            entity_id="user_err",
+            features={"completely_unknown_feature": 123},
+        )


### PR DESCRIPTION
This PR introduces MCP tool integrations to the `feature_store` module, providing seamless access for intelligent agents to register features, ingest values, and retrieve feature vectors. It also resolves missing initialization docstrings, updates the documentation files, and includes complete zero-mock unit tests. All changes adhere strictly to the project's zero-mock testing policy and type annotations.

---
*PR created automatically by Jules for task [5052717192543533959](https://jules.google.com/task/5052717192543533959) started by @docxology*