### PR TITLE
feat: improve demos module with docstrings and mcp tools

### DIFF
--- a/src/codomyrmex/demos/AGENTS.md
+++ b/src/codomyrmex/demos/AGENTS.md
@@ -10,5 +10,6 @@
 - Always provide a `description` and `module` for each registered demo.
 - Demos should return a boolean success status and optional metadata.
 
-## CLI Integration
+## CLI and AI Integration
 - Demos should be runnable via `scripts/demos/` and the main `codomyrmex` CLI.
+- The `mcp_tools.py` exposes `demos_list_demos` and `demos_run_demo` via `@mcp_tool` for agents.

--- a/src/codomyrmex/demos/PAI.md
+++ b/src/codomyrmex/demos/PAI.md
@@ -36,6 +36,6 @@ print(f"Status: {result.status}, Output: {result.output}")
 
 ## Integration Notes
 
-- No `mcp_tools.py` -- this module is not auto-discovered via MCP.
+- Exposed via `mcp_tools.py` to allow AI agents to list and run demos.
 - Used internally for validating module capabilities via demonstration scripts.
 - Call directly from Python when PAI agents need to run or list demos.

--- a/src/codomyrmex/demos/README.md
+++ b/src/codomyrmex/demos/README.md
@@ -10,6 +10,11 @@ The `demos` module provides a centralized registry and orchestration framework f
 
 ## Usage
 
+### MCP Tools Integration
+The module exposes two tools via `@mcp_tool` in `mcp_tools.py` to allow agents to discover and trigger demonstrations:
+- `demos_list_demos`
+- `demos_run_demo`
+
 ### Registering a Demo
 
 ```python

--- a/src/codomyrmex/demos/SPEC.md
+++ b/src/codomyrmex/demos/SPEC.md
@@ -21,6 +21,9 @@ Provide a unified way to register, discover, and execute demonstrations of Codom
 - Leverages `codomyrmex.orchestrator.thin` for running demos.
 - Handles timeouts and logging.
 
+### 5. MCP Tools Integration
+- Exposes `demos_list_demos` and `demos_run_demo` via `@mcp_tool` for system-wide execution and testing.
+
 ## Data Structures
 
 ```python

--- a/src/codomyrmex/demos/mcp_tools.py
+++ b/src/codomyrmex/demos/mcp_tools.py
@@ -1,0 +1,51 @@
+"""MCP tools for the demos module."""
+
+from codomyrmex.demos.registry import DemoResult, get_registry
+from codomyrmex.model_context_protocol.decorators import mcp_tool
+
+
+@mcp_tool(category="demos")
+def demos_list_demos(module: str | None = None, category: str | None = None) -> list[dict]:
+    """
+    List all registered demonstrations.
+
+    Args:
+        module: Optional module name to filter demos by.
+        category: Optional category name to filter demos by.
+
+    Returns:
+        A list of dictionaries containing demonstration metadata.
+    """
+    registry = get_registry()
+    demos = registry.list_demos(module=module, category=category)
+    return [
+        {
+            "name": d.name,
+            "description": d.description,
+            "module": d.module,
+            "category": d.category,
+        }
+        for d in demos
+    ]
+
+
+@mcp_tool(category="demos")
+def demos_run_demo(name: str) -> dict:
+    """
+    Run a specified demonstration by name.
+
+    Args:
+        name: The name of the demo to run.
+
+    Returns:
+        A dictionary containing the results of the demonstration execution.
+    """
+    registry = get_registry()
+    result: DemoResult = registry.run_demo(name)
+    return {
+        "name": result.name,
+        "success": result.success,
+        "output": result.output,
+        "error": result.error,
+        "execution_time": result.execution_time,
+    }

--- a/src/codomyrmex/demos/registry.py
+++ b/src/codomyrmex/demos/registry.py
@@ -40,6 +40,7 @@ class DemoRegistry:
     """Registry for managing and running demonstrations."""
 
     def __init__(self) -> None:
+        """Initialize a new DemoRegistry."""
         self._demos: dict[str, DemoInfo] = {}
 
     def register(
@@ -186,6 +187,7 @@ def demo(
 ) -> Callable:
     """Decorator to register a function as a demo."""
     def decorator(func: Callable) -> Callable:
+        """Process the decorated demo function."""
         demo_name = name or func.__name__
         demo_desc = description or (func.__doc__ or "").split("\n")[0]
 
@@ -207,6 +209,7 @@ def demo(
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
+            """Execute the registered demo."""
             return func(*args, **kwargs)
         return wrapper
 

--- a/src/codomyrmex/image/README.md
+++ b/src/codomyrmex/image/README.md
@@ -1,0 +1,3 @@
+# Image Module
+
+The `image` module handles image generation, manipulation, and analysis (e.g., captioning, OCR, format conversion, and resizing).

--- a/src/codomyrmex/logit_processor/README.md
+++ b/src/codomyrmex/logit_processor/README.md
@@ -1,0 +1,3 @@
+# Logit Processor Module
+
+The `logit_processor` module provides tools to manipulate logit probabilities before text generation.

--- a/src/codomyrmex/tests/unit/demos/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/demos/test_mcp_tools.py
@@ -1,10 +1,9 @@
 """Zero-mock unit tests for demos module MCP tools."""
 
+import pytest
+
 from codomyrmex.demos.mcp_tools import demos_list_demos, demos_run_demo
 from codomyrmex.demos.registry import get_registry
-
-
-import pytest
 
 
 @pytest.fixture
@@ -23,7 +22,13 @@ def test_demos_list_demos(clean_registry):
     def dummy_demo():
         return True
 
-    clean_registry.register("dummy_test_demo", "Dummy description", dummy_demo, module="dummy_module", category="dummy_category")
+    clean_registry.register(
+        "dummy_test_demo",
+        "Dummy description",
+        dummy_demo,
+        module="dummy_module",
+        category="dummy_category",
+    )
 
     results = demos_list_demos()
     assert isinstance(results, list)

--- a/src/codomyrmex/tests/unit/demos/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/demos/test_mcp_tools.py
@@ -1,0 +1,77 @@
+"""Zero-mock unit tests for demos module MCP tools."""
+
+from codomyrmex.demos.mcp_tools import demos_list_demos, demos_run_demo
+from codomyrmex.demos.registry import get_registry
+
+
+import pytest
+
+
+@pytest.fixture
+def clean_registry():
+    """Fixture to ensure the registry is clean before and after tests."""
+    registry = get_registry()
+    # Save the original state
+    original_demos = registry._demos.copy()
+    yield registry
+    # Restore the original state
+    registry._demos = original_demos
+
+
+def test_demos_list_demos(clean_registry):
+    # Register a temporary demo to ensure the list is not empty
+    def dummy_demo():
+        return True
+
+    clean_registry.register("dummy_test_demo", "Dummy description", dummy_demo, module="dummy_module", category="dummy_category")
+
+    results = demos_list_demos()
+    assert isinstance(results, list)
+
+    # Check if our dummy is in the results
+    dummy_found = False
+    for res in results:
+        if res["name"] == "dummy_test_demo":
+            dummy_found = True
+            assert res["description"] == "Dummy description"
+            assert res["module"] == "dummy_module"
+            assert res["category"] == "dummy_category"
+
+    assert dummy_found, "The registered dummy demo was not found by demos_list_demos"
+
+    # Test filtering
+    filtered_results = demos_list_demos(module="dummy_module")
+    assert all(r["module"] == "dummy_module" for r in filtered_results)
+    assert len(filtered_results) > 0
+
+
+def test_demos_run_demo(clean_registry):
+    # Register a successful temporary demo
+    def success_demo():
+        return "Success Output"
+
+    clean_registry.register("success_test_demo", "A successful demo", success_demo)
+
+    res = demos_run_demo("success_test_demo")
+    assert res["name"] == "success_test_demo"
+    assert res["success"] is True
+    assert res["output"] == "Success Output"
+    assert res["error"] is None
+    assert "execution_time" in res
+
+    # Register a failing temporary demo
+    def fail_demo():
+        raise ValueError("Intentional Failure")
+
+    clean_registry.register("fail_test_demo", "A failing demo", fail_demo)
+
+    res2 = demos_run_demo("fail_test_demo")
+    assert res2["name"] == "fail_test_demo"
+    assert res2["success"] is False
+    assert "Intentional Failure" in res2["error"]
+
+    # Test non-existent demo
+    res3 = demos_run_demo("nonexistent_demo_xyz")
+    assert res3["name"] == "nonexistent_demo_xyz"
+    assert res3["success"] is False
+    assert "not found" in res3["error"]


### PR DESCRIPTION
This PR updates the demos module to expose its registry capabilities to AI agents via the MCP protocol. It resolves missing docstrings, exposes `demos_list_demos` and `demos_run_demo` as `@mcp_tool` endpoints, updates the corresponding documentation (PAI.md, README.md, etc.) to reflect these changes, and provides full strictly zero-mock test coverage.

---
*PR created automatically by Jules for task [18364721327109251093](https://jules.google.com/task/18364721327109251093) started by @docxology*