### PR TITLE
Improve concurrency module docs and tests

### DIFF
--- a/src/codomyrmex/concurrency/dead_letter.py
+++ b/src/codomyrmex/concurrency/dead_letter.py
@@ -30,9 +30,11 @@ class DeadLetterQueue:
 
     Args:
         path: Path to the JSONL file for persistence.
+
     """
 
     def __init__(self, path: str | Path = "/tmp/codomyrmex-dlq.jsonl"):
+        """Initialize the dead letter queue."""
         self._path = Path(path)
         self._lock = threading.Lock()
         self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -55,6 +57,7 @@ class DeadLetterQueue:
 
         Returns:
             Entry ID (UUID).
+
         """
         entry_id = str(uuid.uuid4())
         entry = {
@@ -87,6 +90,7 @@ class DeadLetterQueue:
 
         Returns:
             List of entry dicts.
+
         """
         entries: list[dict[str, Any]] = []
         with self._lock:
@@ -123,6 +127,7 @@ class DeadLetterQueue:
 
         Returns:
             Dict with replay outcome.
+
         """
         entries = self.list_entries(include_replayed=True)
         target = next((e for e in entries if e["id"] == entry_id), None)
@@ -164,6 +169,7 @@ class DeadLetterQueue:
 
         Returns:
             Number of entries removed.
+
         """
         with self._lock:
             if not self._path.exists():

--- a/src/codomyrmex/concurrency/locks/distributed_lock.py
+++ b/src/codomyrmex/concurrency/locks/distributed_lock.py
@@ -14,6 +14,7 @@ class BaseLock(ABC):
     """Abstract base class for all lock implementations."""
 
     def __init__(self, name: str):
+        """Initialize the base lock."""
         self.name = name
         self.is_held = False
 
@@ -27,6 +28,7 @@ class BaseLock(ABC):
 
         Returns:
             True if acquired, False otherwise.
+
         """
         pass
 
@@ -52,6 +54,7 @@ class LocalLock(BaseLock):
     """
 
     def __init__(self, name: str, lock_dir: str = "/tmp/codomyrmex/locks"):
+        """Initialize a local file-based lock."""
         super().__init__(name)
         self.lock_path = os.path.join(lock_dir, f"{name}.lock")
         self._lock_dir = lock_dir

--- a/src/codomyrmex/concurrency/locks/lock_manager.py
+++ b/src/codomyrmex/concurrency/locks/lock_manager.py
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 @dataclass
 class LockStats:
     """Statistics for lock manager telemetry."""
+
     total_locks: int = 0
     total_acquisitions: int = 0
     total_releases: int = 0
@@ -24,6 +25,7 @@ class LockManager:
     """Orchestrates multiple locks and provides multi-resource acquisition."""
 
     def __init__(self):
+        """Initialize the lock manager."""
         self._locks: dict[str, BaseLock] = {}
         self._total_acquisitions = 0
         self._total_releases = 0
@@ -111,6 +113,7 @@ class ReadWriteLock:
     """
 
     def __init__(self):
+        """Initialize a read-write lock."""
         self._lock = threading.Lock()
         self._read_ready = threading.Condition(self._lock)
         self._readers = 0

--- a/src/codomyrmex/concurrency/locks/redis_lock.py
+++ b/src/codomyrmex/concurrency/locks/redis_lock.py
@@ -22,6 +22,7 @@ class RedisLock(BaseLock):
             name: The name of the lock.
             redis_client: A redis.Redis instance.
             ttl: Time-to-live for the lock in seconds.
+
         """
         super().__init__(name)
         self.redis = redis_client
@@ -38,6 +39,7 @@ class RedisLock(BaseLock):
 
         Returns:
             True if acquired, False otherwise.
+
         """
         start_time = time.time()
         while True:
@@ -86,6 +88,7 @@ class RedisLock(BaseLock):
 
         Returns:
             True if extension succeeded, False otherwise.
+
         """
         if not self.is_held:
             return False

--- a/src/codomyrmex/concurrency/mcp_tools.py
+++ b/src/codomyrmex/concurrency/mcp_tools.py
@@ -12,20 +12,20 @@ def concurrency_pool_status() -> dict:
 
     Returns:
         Dictionary with pool size, capacity, and availability.
+
     """
     try:
         from codomyrmex.concurrency import AsyncWorkerPool
 
         pool = AsyncWorkerPool()
-        stats = pool.stats()
+        stats = pool.stats
         return {
             "status": "success",
             "pool_stats": {
-                "max_workers": stats.max_workers,
-                "active_workers": stats.active_workers,
-                "queued_tasks": stats.queued_tasks,
-                "completed_tasks": stats.completed_tasks,
-                "failed_tasks": stats.failed_tasks,
+                "submitted": stats.submitted,
+                "completed": stats.completed,
+                "failed": stats.failed,
+                "total_elapsed_ms": stats.total_elapsed_ms,
             },
         }
     except Exception as e:
@@ -41,6 +41,7 @@ def concurrency_list_locks() -> dict:
 
     Returns:
         Dictionary with a list of lock names and their count.
+
     """
     try:
         from codomyrmex.concurrency import LockManager

--- a/src/codomyrmex/concurrency/result_aggregator.py
+++ b/src/codomyrmex/concurrency/result_aggregator.py
@@ -22,6 +22,7 @@ class AggregateResult:
         results: Individual task results.
         mean_duration_ms: Average processing time.
         worker_stats: Per-worker statistics.
+
     """
 
     total_tasks: int = 0
@@ -33,6 +34,7 @@ class AggregateResult:
 
     @property
     def success_rate(self) -> float:
+        """Return the overall success rate."""
         return self.successful / self.total_tasks if self.total_tasks > 0 else 0.0
 
 
@@ -48,6 +50,7 @@ class ResultAggregator:
     """
 
     def __init__(self) -> None:
+        """Initialize the task result aggregator."""
         self._results: list[TaskResult] = []
 
     @property
@@ -68,6 +71,7 @@ class ResultAggregator:
 
         Returns:
             AggregateResult with summary metrics.
+
         """
         total = len(self._results)
         successful = sum(1 for r in self._results if r.success)

--- a/src/codomyrmex/concurrency/semaphores/semaphore.py
+++ b/src/codomyrmex/concurrency/semaphores/semaphore.py
@@ -13,6 +13,7 @@ class BaseSemaphore(ABC):
     """Abstract base class for all semaphore implementations."""
 
     def __init__(self, value: int = 1):
+        """Initialize base semaphore."""
         if value < 0:
             raise ValueError("Semaphore value must be >= 0")
         self.initial_value = value
@@ -41,6 +42,7 @@ class LocalSemaphore(BaseSemaphore):
     """Local thread-safe semaphore wrapper."""
 
     def __init__(self, value: int = 1):
+        """Initialize a local thread-safe semaphore."""
         super().__init__(value)
         self._semaphore = threading.Semaphore(value)
 
@@ -56,6 +58,7 @@ class AsyncLocalSemaphore(BaseSemaphore):
     """Asyncio-compatible local semaphore."""
 
     def __init__(self, value: int = 1):
+        """Initialize a local asyncio-compatible semaphore."""
         super().__init__(value)
         self._semaphore = asyncio.Semaphore(value)
         self._sync_lock = threading.Lock()
@@ -98,7 +101,7 @@ class AsyncLocalSemaphore(BaseSemaphore):
                 self._sync_count += 1
 
     def acquire(self, timeout: float = 10.0) -> bool:
-        """Synchronous acquisition that bridges to async context safely.
+        """Acquire synchronously, bridging safely to an async context.
 
         If in an event loop, uses a fallback synchronous counter to avoid blocking.
         If no loop is running, creates a temporary one to execute the acquisition.

--- a/src/codomyrmex/concurrency/tasks/task_queue.py
+++ b/src/codomyrmex/concurrency/tasks/task_queue.py
@@ -61,6 +61,7 @@ class Task:
         retry_count: Current retry count.
         status: Current status.
         created_at: Creation timestamp.
+
     """
 
     task_id: str = ""
@@ -74,6 +75,7 @@ class Task:
     created_at: float = field(default_factory=time.time)
 
     def __post_init__(self) -> None:
+        """Initialize task ID if not provided."""
         if not self.task_id:
             self.task_id = f"task-{uuid.uuid4().hex[:10]}"
 
@@ -90,6 +92,7 @@ class TaskQueue:
     """
 
     def __init__(self, max_retries: int = 3) -> None:
+        """Initialize the task queue."""
         self._heap: list[QueueEntry] = []
         self._sequence = 0
         self._in_flight: dict[str, Task] = {}
@@ -122,6 +125,7 @@ class TaskQueue:
 
         Returns:
             True if enqueued, False if duplicate.
+
         """
         if task.task_id in self._seen_ids:
             return False
@@ -143,6 +147,7 @@ class TaskQueue:
 
         Returns:
             Next task, or None if queue is empty.
+
         """
         while self._heap:
             entry = heapq.heappop(self._heap)
@@ -168,6 +173,7 @@ class TaskQueue:
 
         Returns:
             True if acknowledged.
+
         """
         task = self._in_flight.pop(task_id, None)
         if task is not None:
@@ -183,6 +189,7 @@ class TaskQueue:
 
         Returns:
             True if requeued, False if dead-lettered.
+
         """
         task = self._in_flight.pop(task_id, None)
         if task is None:
@@ -205,6 +212,7 @@ class TaskQueue:
 
         Returns:
             Number of tasks requeued.
+
         """
         count = 0
         for task in self._dead_letters:

--- a/src/codomyrmex/concurrency/tasks/task_scheduler.py
+++ b/src/codomyrmex/concurrency/tasks/task_scheduler.py
@@ -29,6 +29,7 @@ class WorkerInfo:
         capabilities: Task types this worker can handle.
         max_concurrent: Maximum concurrent tasks.
         current_load: Tasks currently assigned.
+
     """
 
     worker_id: str
@@ -48,6 +49,7 @@ class TaskScheduler:
     """
 
     def __init__(self, strategy: SchedulingStrategy = SchedulingStrategy.ROUND_ROBIN) -> None:
+        """Initialize the task scheduler."""
         self._strategy = strategy
         self._workers: dict[str, WorkerInfo] = {}
         self._round_robin_index = 0
@@ -55,6 +57,7 @@ class TaskScheduler:
 
     @property
     def worker_count(self) -> int:
+        """Return the number of registered workers."""
         return len(self._workers)
 
     @property
@@ -74,6 +77,7 @@ class TaskScheduler:
             worker_id: Worker identifier.
             capabilities: Task types this worker handles.
             max_concurrent: Max concurrent tasks.
+
         """
         self._workers[worker_id] = WorkerInfo(
             worker_id=worker_id,
@@ -91,6 +95,7 @@ class TaskScheduler:
         Args:
             task_type: Task type to route.
             worker_id: Preferred worker.
+
         """
         self._affinity_map[task_type] = worker_id
 
@@ -102,6 +107,7 @@ class TaskScheduler:
 
         Returns:
             Worker ID, or empty string if no worker available.
+
         """
         if not self._workers:
             return ""
@@ -124,6 +130,7 @@ class TaskScheduler:
 
         Args:
             worker_id: Worker that completed.
+
         """
         info = self._workers.get(worker_id)
         if info and info.current_load > 0:
@@ -134,6 +141,7 @@ class TaskScheduler:
 
         Returns:
             List of (from_worker, to_worker) reassignment suggestions.
+
         """
         if len(self._workers) < 2:
             return []

--- a/src/codomyrmex/concurrency/tasks/task_worker.py
+++ b/src/codomyrmex/concurrency/tasks/task_worker.py
@@ -27,6 +27,7 @@ class TaskResult:
         error: Error message if failed.
         duration_ms: Processing time.
         timestamp: Completion timestamp.
+
     """
 
     task_id: str
@@ -56,6 +57,7 @@ class TaskWorker:
         handler: Callable[[Task], Any] | None = None,
         timeout_ms: float = 30000.0,
     ) -> None:
+        """Initialize the task worker."""
         self._worker_id = worker_id or f"worker-{uuid.uuid4().hex[:8]}"
         self._handler = handler or self._default_handler
         self._timeout_ms = timeout_ms
@@ -65,18 +67,22 @@ class TaskWorker:
 
     @property
     def worker_id(self) -> str:
+        """Return the worker ID."""
         return self._worker_id
 
     @property
     def is_running(self) -> bool:
+        """Return whether the worker is running."""
         return self._running
 
     @property
     def tasks_processed(self) -> int:
+        """Return the number of processed tasks."""
         return self._tasks_processed
 
     @property
     def tasks_failed(self) -> int:
+        """Return the number of failed tasks."""
         return self._tasks_failed
 
     @property
@@ -103,6 +109,7 @@ class TaskWorker:
 
         Returns:
             TaskResult with success/failure status.
+
         """
         start = time.time()
 

--- a/src/codomyrmex/concurrency/workers/channels.py
+++ b/src/codomyrmex/concurrency/workers/channels.py
@@ -15,6 +15,7 @@ T = TypeVar("T")
 @dataclass
 class ChannelClosed(Exception):
     """Raised when attempting to operate on a closed channel."""
+
     pass
 
 
@@ -25,6 +26,7 @@ class Channel(Generic[T]):
     """
 
     def __init__(self, capacity: int = 0) -> None:
+        """Initialize channel."""
         self._capacity = max(0, capacity)
         self._queue: asyncio.Queue[T] = asyncio.Queue(maxsize=max(1, self._capacity))
         self._closed = False

--- a/src/codomyrmex/concurrency/workers/pool.py
+++ b/src/codomyrmex/concurrency/workers/pool.py
@@ -52,9 +52,11 @@ class AsyncWorkerPool:
     Args:
         max_workers: Maximum concurrent tasks.
         name: Pool name for logging.
+
     """
 
     def __init__(self, max_workers: int = 4, *, name: str = "pool"):
+        """Initialize worker pool."""
         self._max_workers = max_workers
         self._name = name
         self._semaphore = asyncio.Semaphore(max_workers)
@@ -63,9 +65,11 @@ class AsyncWorkerPool:
         self._closed = False
 
     async def __aenter__(self) -> AsyncWorkerPool:
+        """Enter async context."""
         return self
 
     async def __aexit__(self, *exc: Any) -> None:
+        """Exit async context."""
         await self.shutdown()
 
     async def submit(
@@ -85,6 +89,7 @@ class AsyncWorkerPool:
 
         Returns:
             TaskResult with success/error details.
+
         """
         if self._closed:
             raise RuntimeError(f"Pool {self._name!r} is shut down")
@@ -124,6 +129,7 @@ class AsyncWorkerPool:
 
         Returns:
             List of TaskResults in input order.
+
         """
         tasks = [
             self.submit(coro_fn, item, task_id=f"{self._name}-{i}")

--- a/src/codomyrmex/concurrency/workers/rate_limiter.py
+++ b/src/codomyrmex/concurrency/workers/rate_limiter.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 @dataclass
 class RateLimitConfig:
     """Configuration for rate limiting."""
+
     max_requests: int = 10
     window_seconds: float = 1.0
     burst_size: int | None = None
@@ -25,6 +26,7 @@ class AsyncTokenBucket:
     """
 
     def __init__(self, rate: float, capacity: int | None = None) -> None:
+        """Initialize rate limiter."""
         self._rate = rate
         self._capacity = capacity or int(rate)
         self._tokens = float(self._capacity)
@@ -57,6 +59,7 @@ class AsyncSlidingWindow:
     """Sliding window rate limiter for async contexts."""
 
     def __init__(self, max_requests: int, window_seconds: float) -> None:
+        """Initialize sliding window rate limiter."""
         self._max_requests = max_requests
         self._window = window_seconds
         self._timestamps: list[float] = []

--- a/src/codomyrmex/tests/unit/concurrency/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/concurrency/test_mcp_tools.py
@@ -1,0 +1,50 @@
+"""Strictly zero-mock unit tests for concurrency MCP tools."""
+
+import pytest
+from codomyrmex.concurrency.mcp_tools import (
+    concurrency_pool_status,
+    concurrency_list_locks,
+)
+from codomyrmex.concurrency import LockManager, LocalLock
+
+
+@pytest.mark.unit
+def test_concurrency_pool_status():
+    """Test the concurrency_pool_status MCP tool."""
+    result = concurrency_pool_status()
+
+    assert isinstance(result, dict)
+    assert result.get("status") == "success"
+
+    pool_stats = result.get("pool_stats")
+    assert isinstance(pool_stats, dict)
+
+    expected_keys = {
+        "submitted",
+        "completed",
+        "failed",
+        "total_elapsed_ms",
+    }
+    for key in expected_keys:
+        assert key in pool_stats
+        assert isinstance(pool_stats[key], (int, float))
+
+
+@pytest.mark.unit
+def test_concurrency_list_locks():
+    """Test the concurrency_list_locks MCP tool."""
+    manager = LockManager()
+    lock_name = "test_mcp_lock"
+    lock = LocalLock(lock_name)
+    manager.register_lock(lock_name, lock)
+
+    result = concurrency_list_locks()
+
+    assert isinstance(result, dict)
+    assert result.get("status") == "success"
+    assert "locks" in result
+    assert isinstance(result.get("locks"), list)
+    assert "count" in result
+    assert isinstance(result.get("count"), int)
+
+    assert len(result["locks"]) == result["count"]


### PR DESCRIPTION
Addresses missing docstrings reported by `ruff` for the `src/codomyrmex/concurrency/` module. Ensures MCP tools are properly covered by zero-mock tests in `test_mcp_tools.py`. Also fixes a bug in the `mcp_tools.py` stats implementation.

---
*PR created automatically by Jules for task [15382578499065616656](https://jules.google.com/task/15382578499065616656) started by @docxology*