### PR TITLE
feat(config_management): Implement and test MCP tools

### DIFF
--- a/src/codomyrmex/config_management/__init__.py
+++ b/src/codomyrmex/config_management/__init__.py
@@ -96,9 +96,70 @@ def cli_commands():
     }
 
 
+from typing import Any
+
+
+def get_config(key: str, default: Any = None, namespace: str = "default") -> Any:
+    """Retrieve a configuration value by key.
+
+    Args:
+        key: Configuration key to look up (e.g., 'database.host').
+        default: Default value if the key is not found.
+        namespace: Configuration namespace. Defaults to 'default'.
+
+    Returns:
+        The configuration value.
+    """
+    manager = ConfigurationManager()
+    config = manager.get_configuration(namespace)
+    if not config:
+        config = manager.load_configuration(namespace)
+    return config.get_value(key, default)
+
+
+def set_config(key: str, value: Any, namespace: str = "default") -> None:
+    """Set a configuration value.
+
+    Args:
+        key: Configuration key to set.
+        value: Value to store.
+        namespace: Configuration namespace. Defaults to 'default'.
+    """
+    manager = ConfigurationManager()
+    config = manager.get_configuration(namespace)
+    if not config:
+        config = manager.load_configuration(namespace)
+    config.set_value(key, value)
+    manager.save_configuration(namespace, f"{manager.config_dir}/{namespace}.yaml")
+
+
+def validate_config(namespace: str = "default") -> dict[str, Any]:
+    """Validate configuration consistency and completeness.
+
+    Args:
+        namespace: Configuration namespace to validate.
+
+    Returns:
+        Validation report dictionary containing valid status and issues.
+    """
+    manager = ConfigurationManager()
+    config = manager.get_configuration(namespace)
+    if not config:
+        config = manager.load_configuration(namespace)
+
+    errors = config.validate()
+    return {
+        "valid": len(errors) == 0,
+        "issues": errors,
+    }
+
+
 # Build __all__ dynamically based on available components
 __all__ = [
     # Configuration management
+    "get_config",
+    "set_config",
+    "validate_config",
     "ConfigurationManager",
     "load_configuration",
     "validate_configuration",

--- a/src/codomyrmex/config_management/__init__.py
+++ b/src/codomyrmex/config_management/__init__.py
@@ -62,6 +62,7 @@ try:
         encrypt_configuration,
         manage_secrets,
     )
+
     SECRET_MANAGEMENT_AVAILABLE = True
 except ImportError:
     # cryptography not available
@@ -70,8 +71,10 @@ except ImportError:
     manage_secrets = None
     SECRET_MANAGEMENT_AVAILABLE = False
 
+
 def cli_commands():
     """Return CLI commands for the config_management module."""
+
     def _show(**kwargs):
         """Show current configuration."""
         mgr = ConfigurationManager()
@@ -92,11 +95,14 @@ def cli_commands():
 
     return {
         "show": {"handler": _show, "help": "Show current configuration"},
-        "validate": {"handler": _validate, "help": "Validate configuration against schemas"},
+        "validate": {
+            "handler": _validate,
+            "help": "Validate configuration against schemas",
+        },
     }
 
 
-from typing import Any
+from typing import Any  # noqa: E402
 
 
 def get_config(key: str, default: Any = None, namespace: str = "default") -> Any:
@@ -179,8 +185,10 @@ __all__ = [
 
 # Add secret management if available
 if SECRET_MANAGEMENT_AVAILABLE:
-    __all__.extend([
-        "SecretManager",
-        "manage_secrets",
-        "encrypt_configuration",
-    ])
+    __all__.extend(
+        [
+            "SecretManager",
+            "manage_secrets",
+            "encrypt_configuration",
+        ]
+    )

--- a/src/codomyrmex/tests/unit/config_management/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/config_management/test_mcp_tools.py
@@ -2,10 +2,15 @@
 
 import os
 import tempfile
+
 import pytest
 
-from codomyrmex.config_management import ConfigurationManager, Configuration
-from codomyrmex.config_management.mcp_tools import get_config, set_config, validate_config
+from codomyrmex.config_management import Configuration, ConfigurationManager
+from codomyrmex.config_management.mcp_tools import (
+    get_config,
+    set_config,
+    validate_config,
+)
 
 
 @pytest.fixture
@@ -28,7 +33,9 @@ def mock_config_manager(temp_config_dir, monkeypatch):
     # Save a test configuration
     config = Configuration(data={"database": {"host": "localhost", "port": 5432}})
     manager.configurations["default"] = config
-    manager.save_configuration("default", os.path.join(manager.config_dir, "default.yaml"))
+    manager.save_configuration(
+        "default", os.path.join(manager.config_dir, "default.yaml")
+    )
 
     return manager
 

--- a/src/codomyrmex/tests/unit/config_management/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/config_management/test_mcp_tools.py
@@ -1,0 +1,110 @@
+"""Unit tests for the config_management MCP tools."""
+
+import os
+import tempfile
+import pytest
+
+from codomyrmex.config_management import ConfigurationManager, Configuration
+from codomyrmex.config_management.mcp_tools import get_config, set_config, validate_config
+
+
+@pytest.fixture
+def temp_config_dir():
+    """Create a temporary directory for configuration files."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield temp_dir
+
+
+@pytest.fixture
+def mock_config_manager(temp_config_dir, monkeypatch):
+    """Fixture to set up a ConfigurationManager with a temporary directory."""
+    # We use monkeypatch to alter os.getcwd() so the default ConfigurationManager uses our temp_dir
+    monkeypatch.chdir(temp_config_dir)
+    os.makedirs(os.path.join(temp_config_dir, "config"), exist_ok=True)
+
+    # Initialize the manager
+    manager = ConfigurationManager()
+
+    # Save a test configuration
+    config = Configuration(data={"database": {"host": "localhost", "port": 5432}})
+    manager.configurations["default"] = config
+    manager.save_configuration("default", os.path.join(manager.config_dir, "default.yaml"))
+
+    return manager
+
+
+@pytest.mark.unit
+def test_get_config_success(mock_config_manager):
+    """Test get_config successfully retrieves a value."""
+    result = get_config("database.host")
+
+    assert result["status"] == "success"
+    assert result["key"] == "database.host"
+    assert result["namespace"] == "default"
+    assert result["value"] == "localhost"
+
+
+@pytest.mark.unit
+def test_get_config_not_found(mock_config_manager):
+    """Test get_config when key is not found."""
+    result = get_config("database.username")
+
+    assert result["status"] == "success"
+    assert result["key"] == "database.username"
+    assert result["value"] is None
+
+
+@pytest.mark.unit
+def test_get_config_error(mock_config_manager):
+    """Test get_config handles errors properly without mocking."""
+    # We pass an integer where a string is expected to cause an AttributeError in split()
+    result = get_config(123)  # type: ignore
+    assert result["status"] == "error"
+    assert "attribute 'split'" in result["message"].lower()
+
+
+@pytest.mark.unit
+def test_set_config_success(mock_config_manager):
+    """Test set_config successfully sets and persists a value."""
+    result = set_config("database.port", 5433)
+
+    assert result["status"] == "success"
+    assert result["key"] == "database.port"
+    assert result["updated"] is True
+
+    # Verify it was actually saved
+    manager = ConfigurationManager()
+    config = manager.load_configuration("default")
+    assert config.get_value("database.port") == 5433
+
+
+@pytest.mark.unit
+def test_set_config_error(mock_config_manager):
+    """Test set_config handles errors properly without mocking."""
+    # Passing a non-string key will cause a split() error
+    result = set_config(123, "value")  # type: ignore
+    assert result["status"] == "error"
+    assert "attribute 'split'" in result["message"].lower()
+
+
+@pytest.mark.unit
+def test_validate_config_success(mock_config_manager):
+    """Test validate_config returns valid result."""
+    result = validate_config()
+
+    assert result["status"] == "success"
+    assert result["namespace"] == "default"
+    assert result["valid"] is True
+    assert result["issues"] == []
+
+
+@pytest.mark.unit
+def test_validate_config_error(mock_config_manager, monkeypatch):
+    """Test validate_config handles errors properly without mocking."""
+    # To cause validate_config to raise an exception, we monkeypatch the get_configuration method on the manager temporarily
+    # Wait, the rule says: "The project's 'zero-mock' policy prohibits mocking core dependencies and application logic"
+    # But we can monkeypatch os variables or paths. Instead of mocking the manager, let's pass a bad namespace type.
+
+    # Passing an integer namespace causes string formatting errors during save/load
+    result = validate_config(namespace=123)  # type: ignore
+    assert result["status"] == "error"


### PR DESCRIPTION
This pull request fulfills the requirements for the `config_management` module by properly adding the necessary MCP tools: `get_config`, `set_config`, and `validate_config`. 

Key additions:
1. Implemented actual logic in `__init__.py` to provide the required functionality matching PAI specifications.
2. Updated `__all__` correctly to export these functions.
3. Enhanced type hints and completed missing docstrings in `mcp_tools.py` and `defaults.py`.
4. Created entirely zero-mock unit tests for `mcp_tools.py` in `test_mcp_tools.py`, hitting natural error pathways by passing incorrect inputs instead of using mocking patches, fully complying with the strict project policy.
5. All tests successfully run and pass.
6. Documentation files correctly verified.

---
*PR created automatically by Jules for task [13798688720530891531](https://jules.google.com/task/13798688720530891531) started by @docxology*