### PR TITLE
Improve softmax_opt module: docstrings, types, and zero-mock tests

### DIFF
--- a/src/codomyrmex/softmax_opt/__init__.py
+++ b/src/codomyrmex/softmax_opt/__init__.py
@@ -1,4 +1,5 @@
 """Numerically stable softmax implementations with online algorithm."""
+
 from .kernel import log_softmax, online_softmax, safe_softmax, softmax
 
 __all__ = ["softmax", "log_softmax", "online_softmax", "safe_softmax"]

--- a/src/codomyrmex/softmax_opt/kernel.py
+++ b/src/codomyrmex/softmax_opt/kernel.py
@@ -1,7 +1,11 @@
+"""Kernel implementations for softmax variations."""
+
+from typing import Any
+
 import numpy as np
 
 
-def softmax(x: np.ndarray, axis: int = -1, temperature: float = 1.0) -> np.ndarray:
+def softmax(x: np.ndarray, axis: int = -1, temperature: float = 1.0) -> np.ndarray[Any, Any]:
     """
     Numerically stable softmax using max subtraction.
 
@@ -23,10 +27,10 @@ def softmax(x: np.ndarray, axis: int = -1, temperature: float = 1.0) -> np.ndarr
     x_scaled = x / temperature
     x_max = np.max(x_scaled, axis=axis, keepdims=True)
     exp_x = np.exp(x_scaled - x_max)
-    return exp_x / np.sum(exp_x, axis=axis, keepdims=True)
+    return np.array(exp_x / np.sum(exp_x, axis=axis, keepdims=True))
 
 
-def log_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
+def log_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray[Any, Any]:
     """
     Numerically stable log-softmax using the log-sum-exp trick.
 
@@ -39,10 +43,10 @@ def log_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
     x_max = np.max(x, axis=axis, keepdims=True)
     shifted = x - x_max
     log_sum_exp = np.log(np.sum(np.exp(shifted), axis=axis, keepdims=True))
-    return shifted - log_sum_exp
+    return np.array(shifted - log_sum_exp)
 
 
-def online_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
+def online_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray[Any, Any]:
     """
     Online softmax using single-pass algorithm (Flash Attention style).
 
@@ -67,7 +71,7 @@ def online_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
     result = np.zeros_like(x_flat)
     for row_idx in range(x_flat.shape[0]):
         row = x_flat[row_idx]
-        m = float('-inf')
+        m = float("-inf")
         d = 0.0
 
         # Single pass to compute max and normalizer
@@ -84,11 +88,11 @@ def online_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
     return np.moveaxis(result, -1, axis)
 
 
-def safe_softmax(x: np.ndarray, axis: int = -1, eps: float = 1e-8) -> np.ndarray:
+def safe_softmax(x: np.ndarray, axis: int = -1, eps: float = 1e-8) -> np.ndarray[Any, Any]:
     """
     Softmax with epsilon for numerical safety in attention masks.
     Adds epsilon to denominator to prevent division by zero.
     """
     x_max = np.max(x, axis=axis, keepdims=True)
     exp_x = np.exp(x - x_max)
-    return exp_x / (np.sum(exp_x, axis=axis, keepdims=True) + eps)
+    return np.array(exp_x / (np.sum(exp_x, axis=axis, keepdims=True) + eps))

--- a/src/codomyrmex/softmax_opt/mcp_tools.py
+++ b/src/codomyrmex/softmax_opt/mcp_tools.py
@@ -1,3 +1,7 @@
+"""MCP tools for the softmax_opt module."""
+
+from typing import Any
+
 import numpy as np
 
 from codomyrmex.model_context_protocol.decorators import mcp_tool
@@ -6,7 +10,9 @@ from .kernel import log_softmax, online_softmax, softmax
 
 
 @mcp_tool(category="softmax_opt")
-def compute_softmax(logits: list[float], temperature: float = 1.0, variant: str = "standard") -> dict:
+def compute_softmax(
+    logits: list[float], temperature: float = 1.0, variant: str = "standard"
+) -> dict[str, Any]:
     """Compute softmax probabilities from logits.
 
     Args:

--- a/src/codomyrmex/tests/unit/softmax_opt/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/softmax_opt/test_mcp_tools.py
@@ -1,0 +1,80 @@
+"""Zero-mock unit tests for softmax_opt MCP tools."""
+
+import numpy as np
+import pytest
+
+from codomyrmex.softmax_opt.mcp_tools import compute_softmax
+
+
+@pytest.mark.unit
+def test_compute_softmax_standard() -> None:
+    logits = [1.0, 2.0, 3.0]
+    result = compute_softmax(logits=logits)
+
+    assert result["status"] == "success"
+    assert "probabilities" in result
+    assert "log_probs" in result
+    assert "entropy" in result
+    assert "max_prob" in result
+    assert "sum_check" in result
+
+    # Check probabilities sum to 1
+    assert abs(result["sum_check"] - 1.0) < 1e-6
+    # Max probability should correspond to the largest logit
+    assert result["max_prob"] == max(result["probabilities"])
+    # 3.0 is the highest, so its probability should be the max
+    assert result["probabilities"][2] == result["max_prob"]
+
+
+@pytest.mark.unit
+def test_compute_softmax_log_variant() -> None:
+    logits = [1.0, 2.0, 3.0]
+    result = compute_softmax(logits=logits, variant="log")
+
+    assert result["status"] == "success"
+    assert abs(result["sum_check"] - 1.0) < 1e-6
+    # For standard and log, outputs should essentially match
+    result_standard = compute_softmax(logits=logits, variant="standard")
+    np.testing.assert_allclose(
+        result["probabilities"], result_standard["probabilities"], rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        result["log_probs"], result_standard["log_probs"], rtol=1e-5
+    )
+
+
+@pytest.mark.unit
+def test_compute_softmax_online_variant() -> None:
+    logits = [100.0, 101.0, 99.0]
+    result = compute_softmax(logits=logits, variant="online")
+
+    assert result["status"] == "success"
+    assert abs(result["sum_check"] - 1.0) < 1e-6
+    # Compare with standard variant
+    result_standard = compute_softmax(logits=logits, variant="standard")
+    np.testing.assert_allclose(
+        result["probabilities"], result_standard["probabilities"], rtol=1e-5
+    )
+    np.testing.assert_allclose(
+        result["log_probs"], result_standard["log_probs"], rtol=1e-5
+    )
+
+
+@pytest.mark.unit
+def test_compute_softmax_temperature() -> None:
+    logits = [1.0, 2.0, 3.0]
+
+    result_cold = compute_softmax(logits=logits, temperature=0.1)  # Peaked
+    result_hot = compute_softmax(logits=logits, temperature=10.0)  # Uniform
+
+    assert result_cold["max_prob"] > result_hot["max_prob"]
+    assert result_cold["entropy"] < result_hot["entropy"]
+    assert abs(result_cold["sum_check"] - 1.0) < 1e-6
+    assert abs(result_hot["sum_check"] - 1.0) < 1e-6
+
+
+@pytest.mark.unit
+def test_compute_softmax_invalid_logits() -> None:
+    # Test with incompatible type to naturally trigger an error instead of using mocks.
+    with pytest.raises((ValueError, TypeError)):
+        compute_softmax(logits=["not", "a", "number"])

--- a/src/codomyrmex/tests/unit/softmax_opt/test_softmax_opt.py
+++ b/src/codomyrmex/tests/unit/softmax_opt/test_softmax_opt.py
@@ -6,19 +6,19 @@ from codomyrmex.softmax_opt import log_softmax, online_softmax, softmax
 
 class TestSoftmax:
     @pytest.mark.unit
-    def test_output_sums_to_one(self):
+    def test_output_sums_to_one(self) -> None:
         x = np.array([1.0, 2.0, 3.0, 4.0])
         out = softmax(x)
         assert abs(np.sum(out) - 1.0) < 1e-6
 
     @pytest.mark.unit
-    def test_all_positive(self):
+    def test_all_positive(self) -> None:
         x = np.array([-5.0, 0.0, 5.0, 100.0])
         out = softmax(x)
         assert np.all(out > 0)
 
     @pytest.mark.unit
-    def test_numerically_stable_large_values(self):
+    def test_numerically_stable_large_values(self) -> None:
         """Should not overflow/underflow for large inputs."""
         x = np.array([1000.0, 1001.0, 999.0])
         out = softmax(x)
@@ -27,15 +27,15 @@ class TestSoftmax:
         assert abs(np.sum(out) - 1.0) < 1e-5
 
     @pytest.mark.unit
-    def test_temperature_scaling(self):
+    def test_temperature_scaling(self) -> None:
         x = np.array([1.0, 2.0, 3.0])
-        out_hot = softmax(x, temperature=0.1)   # peaked
+        out_hot = softmax(x, temperature=0.1)  # peaked
         out_cold = softmax(x, temperature=10.0)  # uniform
         # Low temperature -> max probability higher
         assert np.max(out_hot) > np.max(out_cold)
 
     @pytest.mark.unit
-    def test_2d_along_axis(self):
+    def test_2d_along_axis(self) -> None:
         x = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
         out = softmax(x, axis=1)
         row_sums = np.sum(out, axis=1)
@@ -44,7 +44,7 @@ class TestSoftmax:
 
 class TestLogSoftmax:
     @pytest.mark.unit
-    def test_log_softmax_matches_log_of_softmax(self):
+    def test_log_softmax_matches_log_of_softmax(self) -> None:
         x = np.array([1.0, 2.0, 3.0, 0.5])
         log_sm = log_softmax(x)
         sm_then_log = np.log(softmax(x))
@@ -53,14 +53,14 @@ class TestLogSoftmax:
 
 class TestOnlineSoftmax:
     @pytest.mark.unit
-    def test_online_matches_standard(self):
+    def test_online_matches_standard(self) -> None:
         x = np.array([0.5, 1.0, 2.0, 0.1, -0.5])
         standard = softmax(x)
         online = online_softmax(x)
         np.testing.assert_allclose(online, standard, atol=1e-6)
 
     @pytest.mark.unit
-    def test_online_sums_to_one(self):
+    def test_online_sums_to_one(self) -> None:
         x = np.random.randn(10)
         out = online_softmax(x)
         assert abs(np.sum(out) - 1.0) < 1e-6


### PR DESCRIPTION
Fixes missing docstrings, corrects typing annotations across `softmax_opt`, and implements strictly zero-mock tests for `mcp_tools.py`. Validates the existence and contents of required documentation files (`README.md`, `AGENTS.md`, `SPEC.md`). Verified functionality using `uv run pytest` and static checks via `ruff` and `mypy`.

---
*PR created automatically by Jules for task [1911287128749802975](https://jules.google.com/task/1911287128749802975) started by @docxology*