### PR TITLE
refactor: improve peft module docstrings and add zero mock mcp tool tests

### DIFF
--- a/src/codomyrmex/peft/adapters.py
+++ b/src/codomyrmex/peft/adapters.py
@@ -29,13 +29,11 @@ class PEFTAdapter(ABC):
     @abstractmethod
     def adapt(self, x: np.ndarray, **kwargs) -> np.ndarray:
         """Apply adaptation to input."""
-        ...
 
     @property
     @abstractmethod
     def trainable_params(self) -> int:
         """Number of trainable parameters."""
-        ...
 
 
 class LoRAAdapter(PEFTAdapter):
@@ -50,17 +48,18 @@ class LoRAAdapter(PEFTAdapter):
     """
 
     def __init__(self, d_in: int, d_out: int, rank: int = 4, alpha: float = 8.0):
+        """Initialize LoRA adapter."""
         self.rank = rank
         self.scaling = alpha / rank
         scale = np.sqrt(2.0 / d_in)
-        self.A = np.random.randn(rank, d_in) * scale
-        self.B = np.zeros((d_out, rank))  # B=0 for zero init
+        self.a_matrix = np.random.randn(rank, d_in) * scale
+        self.b_matrix = np.zeros((d_out, rank))  # B=0 for zero init
         self.d_in = d_in
         self.d_out = d_out
 
     def adapt(self, x: np.ndarray, base_output: np.ndarray = None, **kwargs) -> np.ndarray:
         """Compute LoRA delta and add to base output."""
-        lora_output = (x @ self.A.T) @ self.B.T * self.scaling
+        lora_output = (x @ self.a_matrix.T) @ self.b_matrix.T * self.scaling
         if base_output is not None:
             return base_output + lora_output
         return lora_output
@@ -79,6 +78,7 @@ class PrefixTuningAdapter(PEFTAdapter):
     """
 
     def __init__(self, d_model: int, n_prefix: int = 10, n_layers: int = 2):
+        """Initialize Prefix Tuning adapter."""
         self.d_model = d_model
         self.n_prefix = n_prefix
         self.n_layers = n_layers
@@ -118,6 +118,7 @@ class IA3Adapter(PEFTAdapter):
     """
 
     def __init__(self, d_model: int, d_ff: int = None):
+        """Initialize IA3 adapter."""
         self.d_model = d_model
         self.d_ff = d_ff or 4 * d_model
 
@@ -138,9 +139,9 @@ class IA3Adapter(PEFTAdapter):
         """
         if mode == "keys":
             return x * self.l_k
-        elif mode == "values":
+        if mode == "values":
             return x * self.l_v
-        elif mode == "ffn":
+        if mode == "ffn":
             return x * self.l_ff[: x.shape[-1]]
         return x
 

--- a/src/codomyrmex/tests/unit/peft/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/peft/test_mcp_tools.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for the peft module MCP tools.
+
+Strictly zero-mock tests for PEFT adapter creation and comparison tools.
+"""
+
+import pytest
+
+from codomyrmex.peft.mcp_tools import peft_compare_methods, peft_create_adapter
+
+
+class TestMCPTools:
+    """Zero-mock tests for PEFT MCP tools."""
+
+    @pytest.mark.unit
+    def test_create_adapter_lora(self):
+        """Test creating a LoRA adapter via MCP tool."""
+        result = peft_create_adapter(method="lora", d_model=256, rank=4, alpha=8.0)
+
+        assert result["method"] == "lora"
+        assert result["trainable_params"] == (4 * 256 + 256 * 4)  # 2048
+        assert result["full_finetune_params"] == 256 * 256  # 65536
+        assert result["reduction_factor"] == round(65536 / 2048, 2)
+
+    @pytest.mark.unit
+    def test_create_adapter_ia3(self):
+        """Test creating an IA3 adapter via MCP tool."""
+        result = peft_create_adapter(method="ia3", d_model=256)
+
+        assert result["method"] == "ia3"
+        assert result["trainable_params"] == (256 + 256 + 4 * 256)  # 1536
+        assert result["full_finetune_params"] == 256 * 256  # 65536
+        assert result["reduction_factor"] == round(65536 / 1536, 2)
+
+    @pytest.mark.unit
+    def test_create_adapter_prefix(self):
+        """Test creating a Prefix Tuning adapter via MCP tool."""
+        result = peft_create_adapter(method="prefix", d_model=256)
+
+        assert result["method"] == "prefix"
+        assert result["trainable_params"] == (2 * 2 * 10 * 256)  # 10240
+        assert result["full_finetune_params"] == 256 * 256  # 65536
+        assert result["reduction_factor"] == round(65536 / 10240, 2)
+
+    @pytest.mark.unit
+    def test_create_adapter_unknown_raises(self):
+        """Test creating an unknown adapter raises ValueError naturally."""
+        with pytest.raises(
+            ValueError,
+            match="Unknown PEFT method: 'unknown'. Supported: lora, prefix, ia3",
+        ):
+            peft_create_adapter(method="unknown", d_model=256)
+
+    @pytest.mark.unit
+    def test_compare_methods(self):
+        """Test comparing PEFT methods via MCP tool."""
+        result = peft_compare_methods(d_model=512, rank=4)
+
+        assert "full_finetune" in result
+        assert "lora" in result
+        assert "prefix" in result
+        assert "ia3" in result
+
+        assert result["full_finetune"] == 512 * 512
+        assert result["lora"] == (4 * 512 + 512 * 4)
+        assert result["prefix"] == (2 * 2 * 10 * 512)
+        assert result["ia3"] == (512 + 512 + 4 * 512)
+
+        assert result["full_finetune"] > result["prefix"]
+        assert result["prefix"] > result["lora"]
+        assert result["lora"] > result["ia3"]

--- a/src/codomyrmex/tests/unit/peft/test_peft.py
+++ b/src/codomyrmex/tests/unit/peft/test_peft.py
@@ -43,7 +43,7 @@ class TestLoRAAdapter:
     def test_lora_nonzero_b_produces_output(self):
         """When B is non-zero, LoRA should produce non-zero delta."""
         adapter = LoRAAdapter(d_in=32, d_out=32, rank=4)
-        adapter.B = np.random.randn(32, 4) * 0.01  # override zero init
+        adapter.b_matrix = np.random.randn(32, 4) * 0.01  # override zero init
         x = np.random.randn(1, 5, 32)
         output = adapter.adapt(x)
         assert not np.allclose(output, 0.0)
@@ -72,13 +72,13 @@ class TestLoRAAdapter:
     def test_lora_a_shape(self):
         """A matrix should be (rank, d_in)."""
         adapter = LoRAAdapter(d_in=128, d_out=64, rank=8)
-        assert adapter.A.shape == (8, 128)
+        assert adapter.a_matrix.shape == (8, 128)
 
     @pytest.mark.unit
     def test_lora_b_shape(self):
         """B matrix should be (d_out, rank)."""
         adapter = LoRAAdapter(d_in=128, d_out=64, rank=8)
-        assert adapter.B.shape == (64, 8)
+        assert adapter.b_matrix.shape == (64, 8)
 
 
 # ---------------------------------------------------------------------------
@@ -262,54 +262,3 @@ class TestPEFTConfig:
         config = PEFTConfig(method="ia3", rank=8, alpha=16.0)
         assert config.method == "ia3"
         assert config.rank == 8
-
-
-# ---------------------------------------------------------------------------
-# MCP Tools
-# ---------------------------------------------------------------------------
-
-
-class TestMCPTools:
-    """MCP tool interface tests."""
-
-    @pytest.mark.unit
-    def test_create_adapter_lora(self):
-        from codomyrmex.peft.mcp_tools import peft_create_adapter
-
-        result = peft_create_adapter(method="lora", d_model=256, rank=4)
-        assert result["method"] == "lora"
-        assert result["trainable_params"] > 0
-        assert result["reduction_factor"] > 1.0
-
-    @pytest.mark.unit
-    def test_create_adapter_ia3(self):
-        from codomyrmex.peft.mcp_tools import peft_create_adapter
-
-        result = peft_create_adapter(method="ia3", d_model=256)
-        assert result["method"] == "ia3"
-
-    @pytest.mark.unit
-    def test_create_adapter_prefix(self):
-        from codomyrmex.peft.mcp_tools import peft_create_adapter
-
-        result = peft_create_adapter(method="prefix", d_model=256)
-        assert result["method"] == "prefix"
-
-    @pytest.mark.unit
-    def test_create_adapter_unknown_raises(self):
-        from codomyrmex.peft.mcp_tools import peft_create_adapter
-
-        with pytest.raises(ValueError, match="Unknown PEFT method"):
-            peft_create_adapter(method="unknown", d_model=256)
-
-    @pytest.mark.unit
-    def test_compare_methods(self):
-        from codomyrmex.peft.mcp_tools import peft_compare_methods
-
-        result = peft_compare_methods(d_model=512, rank=4)
-        assert "full_finetune" in result
-        assert "lora" in result
-        assert "prefix" in result
-        assert "ia3" in result
-        assert result["full_finetune"] > result["lora"]
-        assert result["full_finetune"] > result["ia3"]


### PR DESCRIPTION
Adds missing docstrings and refactors minor variables in `adapters.py` to resolve pylint warnings. It extracts the MCP tool tests into a new `test_mcp_tools.py` file, expanding them to ensure full coverage under a strictly zero-mock policy. Furthermore, confirms the pre-existing proper documentation standards and MCP tool decorators.

---
*PR created automatically by Jules for task [10393124515917835810](https://jules.google.com/task/10393124515917835810) started by @docxology*