### PR TITLE
Improve prompt_engineering module: tests and typing

### DIFF
--- a/.github/workflows/workflow-coordinator.yml
+++ b/.github/workflows/workflow-coordinator.yml
@@ -239,7 +239,7 @@ jobs:
           fi
           
           echo "strategy=$strategy" >> $GITHUB_OUTPUT
-          echo "modules=$(printf '%s\n' "${affected_modules[@]}" | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
+          echo "modules=$(printf '%s\n' "${affected_modules[@]}" | jq -R . | jq -s .)" >> $GITHUB_OUTPUT
           
           echo "Test strategy: $strategy"
           echo "Affected modules: ${affected_modules[*]}"

--- a/.github/workflows/workflow-coordinator.yml
+++ b/.github/workflows/workflow-coordinator.yml
@@ -239,7 +239,7 @@ jobs:
           fi
           
           echo "strategy=$strategy" >> $GITHUB_OUTPUT
-          echo "modules=$(printf '%s\n' "${affected_modules[@]}" | jq -R . | jq -s .)" >> $GITHUB_OUTPUT
+          echo "modules=$(printf '%s\n' "${affected_modules[@]}" | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
           
           echo "Test strategy: $strategy"
           echo "Affected modules: ${affected_modules[*]}"

--- a/src/codomyrmex/prompt_engineering/__init__.py
+++ b/src/codomyrmex/prompt_engineering/__init__.py
@@ -52,15 +52,15 @@ from .versioning import (
 try:
     from codomyrmex.validation.schemas import Config, Result, ResultStatus
 except ImportError:
-    Result = None
-    ResultStatus = None
-    Config = None
+    Result = Any  # type: ignore
+    ResultStatus = Any  # type: ignore
+    Config = Any  # type: ignore
 
 # Try to import base exception for module error class
 try:
     from codomyrmex.exceptions import CodomyrmexError
 except ImportError:
-    CodomyrmexError = Exception
+    CodomyrmexError = Exception  # type: ignore
 
 
 class PromptEngineeringError(CodomyrmexError):
@@ -88,7 +88,7 @@ def list_strategies() -> list[str]:
     return PromptOptimizer().available_strategies()
 
 
-def quick_evaluate(prompt: str, response: str) -> dict:
+def quick_evaluate(prompt: str, response: str) -> dict[str, Any]:
     """
     Run a quick evaluation of a prompt-response pair using default criteria.
 
@@ -104,7 +104,7 @@ def quick_evaluate(prompt: str, response: str) -> dict:
     return result.to_dict()
 
 
-def cli_commands() -> dict:
+def cli_commands() -> dict[str, Any]:
     """
     Return CLI command definitions for the prompt_engineering module.
 

--- a/src/codomyrmex/prompt_engineering/evaluation.py
+++ b/src/codomyrmex/prompt_engineering/evaluation.py
@@ -16,8 +16,8 @@ from typing import Any
 try:
     from codomyrmex.validation.schemas import Result, ResultStatus
 except ImportError:
-    Result = None
-    ResultStatus = None
+    Result = Any  # type: ignore
+    ResultStatus = Any  # type: ignore
 
 
 @dataclass

--- a/src/codomyrmex/prompt_engineering/mcp_tools.py
+++ b/src/codomyrmex/prompt_engineering/mcp_tools.py
@@ -5,7 +5,7 @@ as auto-discovered MCP tools via the ``@mcp_tool`` decorator.
 Zero external dependencies beyond the prompt_engineering module itself.
 """
 
-from __future__ import annotations
+from typing import Any
 
 from codomyrmex.model_context_protocol.decorators import mcp_tool
 
@@ -45,7 +45,7 @@ def prompt_list_strategies() -> list[str]:
         "Returns a dictionary with per-criterion scores and a weighted total."
     ),
 )
-def prompt_evaluate(prompt: str, response: str) -> dict:
+def prompt_evaluate(prompt: str, response: str) -> dict[str, Any]:
     """Evaluate a prompt-response pair and return scores.
 
     Args:

--- a/src/codomyrmex/prompt_engineering/optimization.py
+++ b/src/codomyrmex/prompt_engineering/optimization.py
@@ -16,8 +16,8 @@ from typing import Any
 try:
     from codomyrmex.validation.schemas import Result, ResultStatus
 except ImportError:
-    Result = None
-    ResultStatus = None
+    Result = Any  # type: ignore
+    ResultStatus = Any  # type: ignore
 
 from .templates import PromptTemplate
 

--- a/src/codomyrmex/prompt_engineering/templates.py
+++ b/src/codomyrmex/prompt_engineering/templates.py
@@ -7,6 +7,7 @@ storing, and rendering prompt templates with variable substitution.
 
 from __future__ import annotations
 
+import builtins
 import re
 from dataclasses import dataclass, field
 from typing import Any
@@ -14,9 +15,9 @@ from typing import Any
 try:
     from codomyrmex.validation.schemas import Config, Result, ResultStatus
 except ImportError:
-    Config = None
-    Result = None
-    ResultStatus = None
+    Config = Any  # type: ignore
+    Result = Any  # type: ignore
+    ResultStatus = Any  # type: ignore
 
 
 @dataclass
@@ -182,7 +183,7 @@ class TemplateRegistry:
             raise KeyError(f"Template '{name}' not found in registry.")
         return self._templates.pop(name)
 
-    def list(self) -> list[str]:
+    def list(self) -> builtins.list[str]:
         """
         List all registered template names.
 
@@ -191,7 +192,7 @@ class TemplateRegistry:
         """
         return sorted(self._templates.keys())
 
-    def list_templates(self) -> list[PromptTemplate]:
+    def list_templates(self) -> builtins.list[PromptTemplate]:
         """
         List all registered templates.
 
@@ -215,7 +216,7 @@ class TemplateRegistry:
         template = self.get(template_name)
         return template.render(**kwargs)
 
-    def search(self, query: str) -> list[PromptTemplate]:
+    def search(self, query: str) -> builtins.list[PromptTemplate]:
         """
         Search templates by name or metadata keyword.
 
@@ -238,7 +239,7 @@ class TemplateRegistry:
                 results.append(template)
         return sorted(results, key=lambda t: t.name)
 
-    def export_all(self) -> list[dict[str, Any]]:
+    def export_all(self) -> builtins.list[dict[str, Any]]:
         """
         Export all templates as a list of dictionaries.
 
@@ -247,7 +248,7 @@ class TemplateRegistry:
         """
         return [t.to_dict() for t in self.list_templates()]
 
-    def import_all(self, data: list[dict[str, Any]], overwrite: bool = False) -> int:
+    def import_all(self, data: builtins.list[dict[str, Any]], overwrite: bool = False) -> int:
         """
         Import templates from a list of dictionaries.
 

--- a/src/codomyrmex/prompt_engineering/testing/__init__.py
+++ b/src/codomyrmex/prompt_engineering/testing/__init__.py
@@ -6,6 +6,8 @@ Systematic prompt evaluation and A/B testing.
 
 __version__ = "0.1.0"
 
+from typing import Any
+
 from .evaluators import (
     ContainsEvaluator,
     CustomEvaluator,
@@ -25,11 +27,11 @@ from .runner import ABTest, PromptTester, PromptTestSuite
 try:
     from codomyrmex.validation.schemas import Result, ResultStatus
 except ImportError:
-    Result = None
-    ResultStatus = None
+    Result = Any  # type: ignore
+    ResultStatus = Any  # type: ignore
 
 
-def cli_commands():
+def cli_commands() -> dict[str, Any]:
     """Return CLI commands for the prompt_testing module."""
     return {
         "suites": lambda: print(

--- a/src/codomyrmex/prompt_engineering/versioning.py
+++ b/src/codomyrmex/prompt_engineering/versioning.py
@@ -15,8 +15,8 @@ from typing import Any
 try:
     from codomyrmex.validation.schemas import Result, ResultStatus
 except ImportError:
-    Result = None
-    ResultStatus = None
+    Result = Any  # type: ignore
+    ResultStatus = Any  # type: ignore
 
 from .templates import PromptTemplate
 

--- a/src/codomyrmex/tests/unit/prompt_engineering/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/prompt_engineering/test_mcp_tools.py
@@ -1,0 +1,63 @@
+import pytest
+
+from codomyrmex.prompt_engineering.mcp_tools import (
+    prompt_evaluate,
+    prompt_list_strategies,
+    prompt_list_templates,
+)
+from codomyrmex.prompt_engineering.templates import PromptTemplate, get_default_registry
+
+
+def test_prompt_list_templates():
+    """Test prompt_list_templates MCP tool without mocks."""
+    registry = get_default_registry()
+
+    # Store existing to restore later
+    original_templates = registry._templates.copy()
+
+    try:
+        # Clear default registry and add test templates
+        registry._templates.clear()
+
+        template1 = PromptTemplate(name="test_tool_t1", template_str="Hello {name}")
+        template2 = PromptTemplate(name="test_tool_t2", template_str="Goodbye {name}")
+
+        registry.add(template1)
+        registry.add(template2)
+
+        result = prompt_list_templates()
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert "test_tool_t1" in result
+        assert "test_tool_t2" in result
+
+    finally:
+        # Restore original templates
+        registry._templates.clear()
+        registry._templates.update(original_templates)
+
+
+def test_prompt_list_strategies():
+    """Test prompt_list_strategies MCP tool without mocks."""
+    result = prompt_list_strategies()
+
+    assert isinstance(result, list)
+    assert len(result) >= 0
+    # Even if empty, it should be a list of strings
+    if result:
+        assert isinstance(result[0], str)
+
+
+def test_prompt_evaluate():
+    """Test prompt_evaluate MCP tool without mocks."""
+    prompt = "What is the capital of France?"
+    response = "The capital of France is Paris."
+
+    result = prompt_evaluate(prompt, response)
+
+    assert isinstance(result, dict)
+    assert "weighted_score" in result
+    assert isinstance(result["weighted_score"], (int, float))
+    assert "scores" in result
+    assert isinstance(result["scores"], dict)

--- a/src/codomyrmex/tests/unit/prompt_engineering/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/prompt_engineering/test_mcp_tools.py
@@ -1,4 +1,3 @@
-import pytest
 
 from codomyrmex.prompt_engineering.mcp_tools import (
     prompt_evaluate,


### PR DESCRIPTION
This commit improves the `prompt_engineering` module:
- Fixes `mypy` typing errors across multiple files by correctly assigning fallback types (`Any # type: ignore`) in `except ImportError` blocks.
- Adds missing type parameters for generic `dict` types.
- Fixes return type collision for `list` in `templates.py` by switching to `builtins.list`.
- Adds zero-mock unit tests for MCP tools (`prompt_evaluate`, `prompt_list_templates`, `prompt_list_strategies`) in `src/codomyrmex/tests/unit/prompt_engineering/test_mcp_tools.py`.
- Includes proper teardowns to prevent test pollution when modifying global registries.
- Verifies docstrings and documentation files (README, SPEC, AGENTS).

---
*PR created automatically by Jules for task [6734754494408525550](https://jules.google.com/task/6734754494408525550) started by @docxology*