### PR TITLE
🎨 Palette: Add ARIA role="alert" to chat warning banners

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-02-23 - Visual Feedback for Async Buttons
-**Learning:** In async contexts (like chat submissions), simply disabling the input field isn't enough UX feedback. If the submit button itself isn't disabled and lacks a loading indicator, users might attempt double submissions or think the app is unresponsive.
-**Action:** Always pair `input.disabled = true` with a disabled submit button state, ideally injecting a `.loader` visual indicator and updating the button text (e.g. 'Sending...'). Re-enable in the `finally` block to ensure recovery on error.
+## 2024-10-27 - ARIA Alert Role on Dynamic Banners
+**Learning:** Dynamically injected error banners (like the Ollama offline warnings) need `role="alert"` so screen readers immediately announce them to users.
+**Action:** Always verify dynamically inserted DOM elements conveying critical system states include the appropriate ARIA live region attributes (`role="alert"` or `aria-live="assertive"`).

--- a/src/codomyrmex/tests/unit/p3_remediation/test_p3_file_permissions.py
+++ b/src/codomyrmex/tests/unit/p3_remediation/test_p3_file_permissions.py
@@ -10,7 +10,6 @@ Zero-Mock compliant — uses real file operations.
 import stat
 
 import pytest
-
 from codomyrmex.ci_cd_automation.build.pipeline.build_orchestrator import (
     synthesize_build_artifact,
 )

--- a/src/codomyrmex/website/templates/chat.html
+++ b/src/codomyrmex/website/templates/chat.html
@@ -36,6 +36,7 @@
             if (models.length === 0) {
                 sel.innerHTML = '<option value="">No models found</option>';
                 const banner = document.createElement('div');
+                banner.setAttribute('role', 'alert');
                 banner.style.cssText = 'padding: 0.75rem 1rem; background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.3); border-radius: 8px; margin-bottom: 1rem; color: #f87171; font-size: 0.85rem;';
                 banner.innerHTML = '⚠️ <strong>Ollama not available</strong> — No models found. Start Ollama with <code style="font-size:0.8rem">ollama serve</code> and pull a model.';
                 document.querySelector('.chat-container').prepend(banner);
@@ -51,6 +52,7 @@
         } catch (e) {
             document.getElementById('model-select').innerHTML = '<option value="">Ollama offline</option>';
             const banner = document.createElement('div');
+            banner.setAttribute('role', 'alert');
             banner.style.cssText = 'padding: 0.75rem 1rem; background: rgba(239,68,68,0.1); border: 1px solid rgba(239,68,68,0.3); border-radius: 8px; margin-bottom: 1rem; color: #f87171; font-size: 0.85rem;';
             banner.innerHTML = '⚠️ <strong>Ollama offline</strong> — Cannot connect to the LLM backend. Start Ollama with <code style="font-size:0.8rem">ollama serve</code>.';
             document.querySelector('.chat-container').prepend(banner);


### PR DESCRIPTION
💡 What: Added `role="alert"` attribute to the dynamically generated error warning banners when Ollama is offline or unavailable.
🎯 Why: Without this ARIA attribute, screen readers will not announce these important system warnings automatically to visually impaired users, resulting in a critical accessibility gap.
📸 Before/After: The visual style hasn't changed.
♿ Accessibility: Improves accessibility for screen readers by explicitly marking warning banners as alert dialogs using the standard ARIA attribute `role="alert"`.

---
*PR created automatically by Jules for task [2663056762803685614](https://jules.google.com/task/2663056762803685614) started by @docxology*