### PR TITLE
🎨 Palette: add missing screen reader label to script arguments input

### DIFF
--- a/src/codomyrmex/website/templates/scripts.html
+++ b/src/codomyrmex/website/templates/scripts.html
@@ -25,7 +25,8 @@
 
         <form class="script-form" data-script-name="{{ script.path }}" data-script-id="{{ loop.index }}">
             <div style="margin-bottom: 1rem;">
-                <input type="text" name="args" placeholder="Arguments (optional)" style="width: 100%;">
+                <label for="script-args-{{ loop.index }}" class="sr-only">Arguments for {{ script.title }}</label>
+                <input type="text" id="script-args-{{ loop.index }}" name="args" placeholder="Arguments (optional)" style="width: 100%;">
             </div>
             <button type="submit" class="btn btn-primary" style="width: 100%;">Run Script</button>
         </form>


### PR DESCRIPTION
💡 **What**: Added a visually hidden label (`.sr-only`) specifically for the script arguments input field in the `scripts.html` template.
🎯 **Why**: Previously, the input field relied solely on a `placeholder` attribute to convey its purpose. Screen readers and assistive technologies require a proper `<label>` associated with the `<input>` element to provide context to the user.
📸 **Before/After**: Visually, the UI remains exactly the same due to the `.sr-only` class.
♿ **Accessibility**: Resolves a WCAG "Forms without proper labels" violation, ensuring users relying on screen readers hear "Arguments for [Script Title]" when focused on the input field.

---
*PR created automatically by Jules for task [5196178751483642661](https://jules.google.com/task/5196178751483642661) started by @docxology*