### PR TITLE
🔒 fix: remove hardcoded secret in auth mcp tools

### DIFF
--- a/src/codomyrmex/auth/mcp_tools.py
+++ b/src/codomyrmex/auth/mcp_tools.py
@@ -53,12 +53,12 @@ def auth_validate_token(token_value: str) -> dict:
     Returns:
         Dictionary with 'valid' bool and 'reason' string.
     """
-    from codomyrmex.auth import TokenValidator
+    from codomyrmex.auth import get_authenticator
 
-    validator = TokenValidator(secret="mcp_tool_validation_key")
     try:
-        result = validator.validate_signed_token(token_value)
-        if result is None:
+        authenticator = get_authenticator()
+        is_valid = authenticator.token_manager.validate_token(token_value)
+        if not is_valid:
             return {"valid": False, "reason": "invalid or expired token"}
         return {"valid": True, "reason": "ok"}
     except Exception as exc:


### PR DESCRIPTION
🎯 **What:** Removed the hardcoded secret (`"mcp_tool_validation_key"`) from the `auth_validate_token` MCP tool in `src/codomyrmex/auth/mcp_tools.py`.

⚠️ **Risk:** The hardcoded secret allowed complete bypass of the token validation logic. An attacker with knowledge of this codebase-default string could forge valid token payloads (JWT equivalents), gaining unauthorized access to any system relying on this MCP tool for validation.

🛡️ **Solution:** Updated `auth_validate_token` to properly use the centralized authentication manager. It now calls `get_authenticator().token_manager.validate_token()` to verify the token string. This leverages the secure, runtime-configured secret managed by the `Authenticator` singleton.

---
*PR created automatically by Jules for task [4365771607397871814](https://jules.google.com/task/4365771607397871814) started by @docxology*