### PR TITLE
🔒 fix: Remove insecure hardcoded secret from MCP tool validator

### DIFF
--- a/src/codomyrmex/auth/mcp_tools.py
+++ b/src/codomyrmex/auth/mcp_tools.py
@@ -53,11 +53,11 @@ def auth_validate_token(token_value: str) -> dict:
     Returns:
         Dictionary with 'valid' bool and 'reason' string.
     """
-    from codomyrmex.auth import TokenValidator
+    from codomyrmex.auth import get_authenticator
 
-    validator = TokenValidator(secret="mcp_tool_validation_key")
     try:
-        result = validator.validate_signed_token(token_value)
+        authenticator = get_authenticator()
+        result = authenticator.token_manager.validator.validate_signed_token(token_value)
         if result is None:
             return {"valid": False, "reason": "invalid or expired token"}
         return {"valid": True, "reason": "ok"}

--- a/src/codomyrmex/auth/mcp_tools.py
+++ b/src/codomyrmex/auth/mcp_tools.py
@@ -57,7 +57,9 @@ def auth_validate_token(token_value: str) -> dict:
 
     try:
         authenticator = get_authenticator()
-        result = authenticator.token_manager.validator.validate_signed_token(token_value)
+        result = authenticator.token_manager.validator.validate_signed_token(
+            token_value
+        )
         if result is None:
             return {"valid": False, "reason": "invalid or expired token"}
         return {"valid": True, "reason": "ok"}


### PR DESCRIPTION
🎯 **What:** Removed an insecure hardcoded secret from `auth_validate_token`.
⚠️ **Risk:** A hardcoded secret allows anyone with code access to spoof tokens or validate forged tokens, rendering authentication controls ineffective for systems relying on this MCP tool's output.
🛡️ **Solution:** Replaced the hardcoded initialization with `get_authenticator().token_manager.validator.validate_signed_token()`, utilizing the global `Authenticator` singleton's configured and secured secret instead.

---
*PR created automatically by Jules for task [7276748931021907374](https://jules.google.com/task/7276748931021907374) started by @docxology*