### PR TITLE
🧪 test: add test for add_task in task_manager.py

### DIFF
--- a/src/codomyrmex/tests/unit/collaboration/test_coordination.py
+++ b/src/codomyrmex/tests/unit/collaboration/test_coordination.py
@@ -101,12 +101,21 @@ class TestDependencyGraph:
 
         task1 = Task(name="Task 1", id="t1")
         task2 = Task(name="Task 2", id="t2", dependencies=["t1"])
+        task3 = Task(name="Task 3", id="t3", dependencies=["t1", "t2"])
 
         graph.add_task(task1)
         graph.add_task(task2)
+        graph.add_task(task3)
 
-        deps = graph.get_dependencies("t2")
-        assert "t1" in deps
+        # Check dependencies
+        assert graph.get_dependencies("t1") == set()
+        assert graph.get_dependencies("t2") == {"t1"}
+        assert graph.get_dependencies("t3") == {"t1", "t2"}
+
+        # Check dependents
+        assert graph.get_dependents("t1") == {"t2", "t3"}
+        assert graph.get_dependents("t2") == {"t3"}
+        assert graph.get_dependents("t3") == set()
 
     def test_graph_get_ready_tasks(self):
         """Test getting ready tasks."""


### PR DESCRIPTION
🎯 **What:** The testing gap in `src/codomyrmex/collaboration/coordination/task_manager.py:102` for the `add_task` functionality (specifically dependency mappings).
📊 **Coverage:** Now tests that adding tasks properly populate both the dependency state (`get_dependencies`) and reverse tracking mapping (`get_dependents`).
✨ **Result:** Enhanced the unit test reliability without adding any mocked dependencies or risky runtime changes.

---
*PR created automatically by Jules for task [12030868363978656116](https://jules.google.com/task/12030868363978656116) started by @docxology*