### PR TITLE
🧹 refactor: replace custom yaml parser with js-yaml in GitHubSync

### DIFF
--- a/src/codomyrmex/pai_pm/server/GitHubSync.ts
+++ b/src/codomyrmex/pai_pm/server/GitHubSync.ts
@@ -67,6 +67,7 @@
 
 import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from "fs";
 import { join } from "path";
+import { load as parseYaml } from "js-yaml";
 import { homedir } from "os";
 import { execFileSync } from "child_process";
 
@@ -322,51 +323,6 @@ function loadMissionSyncMapping(missionSlug: string): MissionSyncMapping | null 
 // ============================================================================
 // PAI Data Helpers
 // ============================================================================
-
-// TODO(M9): Replace with js-yaml for proper YAML spec compliance
-function parseSimpleYaml(content: string): Record<string, any> {
-  const result: Record<string, any> = {};
-  let currentArrayKey: string | null = null;
-  const currentArray: string[] = [];
-
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-
-    if (trimmed.startsWith("- ") && currentArrayKey) {
-      let value = trimmed.slice(2).trim();
-      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-        value = value.slice(1, -1);
-      }
-      currentArray.push(value);
-      continue;
-    }
-
-    if (currentArrayKey && currentArray.length > 0) {
-      result[currentArrayKey] = [...currentArray];
-      currentArray.length = 0;
-      currentArrayKey = null;
-    }
-
-    const colonIdx = trimmed.indexOf(":");
-    if (colonIdx === -1) continue;
-
-    const key = trimmed.slice(0, colonIdx).trim();
-    let value = trimmed.slice(colonIdx + 1).trim();
-
-    if (!value) { currentArrayKey = key; continue; }
-
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    result[key] = value;
-  }
-
-  if (currentArrayKey && currentArray.length > 0) {
-    result[currentArrayKey] = [...currentArray];
-  }
-  return result;
-}
 
 interface ParsedTasks {
   header: string;
@@ -887,7 +843,7 @@ export function pullFromGitHub(projectSlug: string, dryRun = false): SyncResult 
     tasks = parseTasksMd(readFileSync(tasksPath, "utf-8"));
   } else {
     const yamlPath = join(PROJECTS_DIR, projectSlug, "PROJECT.yaml");
-    const yaml = existsSync(yamlPath) ? parseSimpleYaml(readFileSync(yamlPath, "utf-8")) : {};
+    const yaml = (existsSync(yamlPath) ? parseYaml(readFileSync(yamlPath, "utf-8")) as Record<string, any> : {}) || {};
     tasks = {
       header: `# ${yaml.title || projectSlug} Tasks\n\n${yaml.goal || ""}\n\n---`,
       completed: [], in_progress: [], remaining: [],

--- a/src/codomyrmex/pai_pm/server/bun.lock
+++ b/src/codomyrmex/pai_pm/server/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@codomyrmex/pai-pm",
@@ -8,21 +7,28 @@
         "js-yaml": "^4.1.0",
       },
       "devDependencies": {
-        "@types/bun": "latest",
+        "@types/bun": "^1.3.14",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^26.0.0",
+        "typescript": "^6.0.3",
       },
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
+    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
   }
 }

--- a/src/codomyrmex/pai_pm/server/package.json
+++ b/src/codomyrmex/pai_pm/server/package.json
@@ -17,7 +17,10 @@
         "js-yaml": "^4.1.0"
     },
     "devDependencies": {
-        "@types/bun": "latest"
+        "@types/bun": "^1.3.14",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^26.0.0",
+        "typescript": "^6.0.3"
     },
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
🎯 **What:** Replaced the internal `parseSimpleYaml` function in `GitHubSync.ts` with the standard `js-yaml` package.
💡 **Why:** `parseSimpleYaml` was a limited, custom implementation noted with a `TODO` for replacement. Standard libraries should be used for complex formats like YAML to ensure full specification compliance and reduce maintenance overhead.
✅ **Verification:** Verified compilation using `tsc --noEmit` and `bun build` to check for syntax and type safety. Handled `undefined` edge case from `js-yaml`.
✨ **Result:** Improved codebase maintainability, spec compliance, and readability by removing 45 lines of brittle string-parsing code.

---
*PR created automatically by Jules for task [4874154587129022069](https://jules.google.com/task/4874154587129022069) started by @docxology*