### PR TITLE
🔒 fix(orchestrator): mitigate RCE vulnerability in mcp_tools eval()

### DIFF
--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -137,7 +137,20 @@ def orchestrator_run_dag(
                     return getattr(mod, parts[1])
             if "fn_expr" in task_dict:
                 expr = task_dict["fn_expr"]
-                return lambda *_a, **_kw: eval(expr)
+                if "__" in expr:
+                    raise ValueError(
+                        "Double underscores are not allowed in fn_expr for security reasons."
+                    )
+
+                safe_locals = {
+                    "len": len,
+                    "sum": sum,
+                    "min": min,
+                    "max": max,
+                    "abs": abs,
+                    "round": round,
+                }
+                return lambda *_a, **_kw: eval(expr, {"__builtins__": {}}, safe_locals)
             # Default: identity (return args as-is)
             return lambda *a, **kw: {"args": a, "kwargs": kw}
 

--- a/src/codomyrmex/tests/unit/orchestrator/test_agent_orchestrator_extended.py
+++ b/src/codomyrmex/tests/unit/orchestrator/test_agent_orchestrator_extended.py
@@ -102,6 +102,21 @@ def test_orchestrator_run_dag_rejects_unknown_topology() -> None:
     )
 
 
+def test_orchestrator_run_dag_safe_eval_blocks_malicious_code() -> None:
+    from codomyrmex.orchestrator.mcp_tools import orchestrator_run_dag
+
+    tasks = [{"id": "t1", "fn_expr": "__import__('os').system('ls')"}]
+    result = orchestrator_run_dag("fan_out", tasks)
+    assert result["status"] == "error"
+    assert "Double underscores are not allowed" in result["message"]
+
+    tasks2 = [{"id": "t2", "fn_expr": "len('hello')"}]
+    result2 = orchestrator_run_dag("fan_out", tasks2)
+    assert result2["status"] == "success"
+    assert len(result2["results"]) == 1
+    assert result2["results"][0]["output"] == 5
+
+
 # ── EventStore-backed IntegrationBus durability ───────────────────────────────
 
 


### PR DESCRIPTION
🎯 **What:** The `orchestrator_run_dag` MCP tool was using `eval(expr)` directly on user-provided strings via the `fn_expr` argument, allowing execution of arbitrary Python code.
⚠️ **Risk:** This was a critical security vulnerability (Remote Code Execution), as an attacker could execute system commands by passing malicious expressions (e.g., `__import__('os').system(...)`).
🛡️ **Solution:** The `eval` call is now properly sandboxed. We enforce an empty `__builtins__` dictionary to block importing or accessing environment-level execution capabilities. The fix also prevents sandbox escapes by raising an error on any string containing double underscores (`__`) and only exposes a curated whitelist of safe standard mathematical/sequence functions (`len`, `sum`, `min`, `max`, `abs`, `round`). Comprehensive tests were added to confirm the mitigation.

---
*PR created automatically by Jules for task [12943035005799088935](https://jules.google.com/task/12943035005799088935) started by @docxology*