### PR TITLE
🧪 test: add test coverage for TaskQueue remove and peek in task_manager

### DIFF
--- a/src/codomyrmex/tests/unit/collaboration/test_coordination.py
+++ b/src/codomyrmex/tests/unit/collaboration/test_coordination.py
@@ -75,6 +75,33 @@ class TestTaskQueue:
         assert result is True
         assert queue.pop() is None
 
+        # Test removing a nonexistent task ID
+        result_nonexistent = queue.remove("nonexistent_id")
+        assert result_nonexistent is False
+
+    def test_queue_peek_lazy_removal(self):
+        """Test peeking after a lazy removal."""
+        queue = TaskQueue()
+        task1 = Task(name="Task 1", priority=10)
+        task2 = Task(name="Task 2", priority=5)
+
+        queue.push(task1)
+        queue.push(task2)
+
+        # Remove the highest priority task (task1) lazily
+        queue.remove(task1.id)
+
+        # Peek should bypass the lazily removed task and return task2
+        peeked = queue.peek()
+        assert peeked is not None
+        assert peeked.name == "Task 2"
+
+        # Remove task2 lazily
+        queue.remove(task2.id)
+
+        # Peek should return None as all items are removed lazily
+        assert queue.peek() is None
+
     def test_queue_get(self):
         """Test getting a task by ID."""
         queue = TaskQueue()


### PR DESCRIPTION
🎯 **What:** The testing gap in `TaskQueue`'s `remove` and `peek` methods (in `task_manager.py`) was addressed. The existing `test_queue_remove` test didn't cover the `return False` branch for non-existent IDs. Similarly, `peek()`'s handling of lazily removed tasks (where a task is manually removed from `_tasks` but still present in `_heap`) lacked coverage.

📊 **Coverage:** 
- Tested removing a non-existent task ID to ensure it correctly returns `False`.
- Tested the queue's `peek` method to ensure it successfully bypasses tasks that were lazily removed from the task map but remain in the heap, maintaining correct priority queue behavior.

✨ **Result:** Test coverage for `src/codomyrmex/collaboration/coordination/task_manager.py` is improved, capturing important edge cases involving lazy removals.

---
*PR created automatically by Jules for task [11754791119902181703](https://jules.google.com/task/11754791119902181703) started by @docxology*