### PR TITLE
🧹 Remove unused 'os' import from codomyrmex/__init__.py

### DIFF
--- a/src/codomyrmex/__init__.py
+++ b/src/codomyrmex/__init__.py
@@ -7,7 +7,6 @@ documentation, and workflow automation. See package README and
 
 __version__ = "1.2.7"
 
-import os
 import pkgutil
 from pathlib import Path
 


### PR DESCRIPTION
🎯 **What:** Removed an unused `import os` statement from `src/codomyrmex/__init__.py`.
💡 **Why:** To improve code health and maintainability by removing unused modules from the top-level package namespace.
✅ **Verification:** Ran `uv run ruff check` and `uv run ruff format` to ensure code style compliance. Tested the package load via `uv run python -c "import codomyrmex; print(codomyrmex.get_version())"`, which confirmed no import loops or SyntaxErrors were introduced. Evaluated the file with `grep` to ensure `os` was absolutely unreferenced.
✨ **Result:** The `codomyrmex` module no longer unnecessarily imports `os`.

---
*PR created automatically by Jules for task [4078396335370204563](https://jules.google.com/task/4078396335370204563) started by @docxology*