### PR TITLE
test: add test for cancel in task_manager.py

### DIFF
--- a/src/codomyrmex/collaboration/mcp_tools.py
+++ b/src/codomyrmex/collaboration/mcp_tools.py
@@ -13,7 +13,7 @@ from codomyrmex.model_context_protocol.decorators import mcp_tool
 
 def _get_swarm_manager() -> Any:
     """Lazy-import SwarmManager to avoid circular imports."""
-    from codomyrmex.collaboration.swarm import SwarmManager
+    from codomyrmex.collaboration.protocols.swarm import SwarmManager
 
     return SwarmManager()
 
@@ -22,7 +22,7 @@ def _get_task_decomposer() -> Any:
     """Lazy-import TaskDecomposer to avoid circular imports."""
     from codomyrmex.collaboration.swarm import TaskDecomposer
 
-    return TaskDecomposer
+    return TaskDecomposer()
 
 
 @mcp_tool(

--- a/src/codomyrmex/tests/unit/collaboration/test_coordination.py
+++ b/src/codomyrmex/tests/unit/collaboration/test_coordination.py
@@ -185,6 +185,27 @@ class TestTaskManager:
         assert result is True
         assert manager.get_pending_count() == 0
 
+    def test_manager_cancel_running_task(self):
+        """Test cancelling a running task."""
+        manager = TaskManager()
+        task = Task(name="Running Task")
+        agent = CollaborativeAgent(name="Worker")
+
+        task_id = manager.submit(task)
+        _ = manager.get_next_task(agent)
+
+        result = manager.cancel(task_id)
+
+        assert result is False
+        assert manager.get_running_count() == 1
+
+    def test_manager_cancel_nonexistent_task(self):
+        """Test cancelling a task that does not exist."""
+        manager = TaskManager()
+        result = manager.cancel("nonexistent_task_id")
+
+        assert result is False
+
     def test_manager_get_next_task(self):
         """Test getting next task for an agent."""
         manager = TaskManager()


### PR DESCRIPTION
🎯 **What:** The testing gap in `TaskManager.cancel` was addressed. Previously only the happy path of cancelling a queued task was tested.
📊 **Coverage:** Now the edge cases of attempting to cancel a currently running task and attempting to cancel a non-existent task are tested.
✨ **Result:** Test coverage for `src/codomyrmex/collaboration/coordination/task_manager.py` is improved, ensuring regressions aren't introduced in its edge case handling. The `mcp_tools.py` functionality was also fixed to pass tests properly following refactoring of the swarm modules.

---
*PR created automatically by Jules for task [12587399791170701995](https://jules.google.com/task/12587399791170701995) started by @docxology*