### PR TITLE
⚡ perf: replace synchronous time.sleep with async delegation in trajectory compressor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2026-03-10 - Refactored Synchronous API Wrappers for asyncio Completeness
+
+**Vulnerability/Performance Issue:** Synchronous blocking `time.sleep` calls were present in retry loops during API interaction logic. When the framework executes in an event loop environment, these synchronous blocking calls could stall the event loop. Furthermore, maintaining split implementation blocks (sync vs async) introduced duplication and bugs.
+**Learning:** `asyncio.run()` cannot be called when an event loop is already running. For unified API endpoints needing sync wrappers that might be called within existing asyncio event loops, standard practice is to use a ThreadPoolExecutor wrapper (`pool.submit(asyncio.run, coro).result()`) to isolate the new loop from the running one, thus preventing `RuntimeError: asyncio.run() cannot be called from a running event loop`.
+**Prevention:** Avoid split sync/async codebase logic if async wrappers or pure async calls are sufficient. Always test sync-wrapper methods in an event loop environment (e.g., using `pytest.mark.asyncio`) to catch runtime boundary errors.


### PR DESCRIPTION
Refactored the synchronous `_generate_summary` method to serve as a wrapper around the asynchronous `_generate_summary_async` implementation. This unifies the logic, avoids duplicating the LLM prompt and retry logic, and correctly solves the issue of `time.sleep` blocking threads. The synchronous wrapper uses a `ThreadPoolExecutor` to safely run `asyncio.run` when an event loop is already running, preventing runtime loop interference. Fixed the test cases to use the async client mock logic properly.

---
*PR created automatically by Jules for task [18274553447268061800](https://jules.google.com/task/18274553447268061800) started by @docxology*