### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix code injection in orchestrator_run_dag

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - Prevent Code Injection in Swarm Topology Execution
+**Vulnerability:** The `orchestrator_run_dag` MCP tool was using `eval` on the `fn_expr` parameter directly from a task dictionary. While it restricted builtins and used a `__` double underscore check, a malicious input could still access powerful functions via reflection or bypass checks by string parsing or avoiding `__`, resulting in remote code execution (RCE).
+**Learning:** Python's `eval()` is incredibly dangerous even when passed empty `__builtins__`. Attackers can use string manipulation, reflection, or AST loopholes to bypass the restrictions.
+**Prevention:** Using `ast.parse` and explicitly defining which AST nodes (e.g. `ast.BinOp`, `ast.Call` on specific `safe_locals`) are permitted ensures that only mathematically and functionally safe operations can run, completely preventing code injection. Never use `eval` on untrusted input; use restricted AST parsers instead.

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -119,7 +119,9 @@ def orchestrator_run_dag(
         Aggregated result dict with per-task outputs, success/error counts.
     """
     try:
+        import ast
         import importlib
+        import operator
 
         from codomyrmex.orchestrator.swarm_topology import (
             SwarmTopology,
@@ -150,7 +152,46 @@ def orchestrator_run_dag(
                     "abs": abs,
                     "round": round,
                 }
-                return lambda *_a, **_kw: eval(expr, {"__builtins__": {}}, safe_locals)
+
+                _ALLOWED_OPS = {
+                    ast.Add: operator.add,
+                    ast.Sub: operator.sub,
+                    ast.Mult: operator.mul,
+                    ast.Div: operator.truediv,
+                    ast.FloorDiv: operator.floordiv,
+                    ast.Mod: operator.mod,
+                    ast.Pow: operator.pow,
+                    ast.USub: operator.neg,
+                    ast.UAdd: operator.pos,
+                }
+
+                def _safe_eval_ast(node: ast.AST) -> float:
+                    """Recursively evaluate an AST node containing only arithmetic and specific functions."""
+                    if isinstance(node, ast.Expression):
+                        return _safe_eval_ast(node.body)
+                    if isinstance(node, ast.Constant) and isinstance(
+                        node.value, (int, float, str)
+                    ):
+                        return node.value
+                    if isinstance(node, ast.BinOp) and type(node.op) in _ALLOWED_OPS:
+                        return _ALLOWED_OPS[type(node.op)](
+                            _safe_eval_ast(node.left),
+                            _safe_eval_ast(node.right),  # type: ignore
+                        )
+                    if isinstance(node, ast.UnaryOp) and type(node.op) in _ALLOWED_OPS:
+                        return _ALLOWED_OPS[type(node.op)](_safe_eval_ast(node.operand))  # type: ignore
+                    if (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Name)
+                        and node.func.id in safe_locals
+                    ):
+                        args = [_safe_eval_ast(arg) for arg in node.args]
+                        return safe_locals[node.func.id](*args)
+                    raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+                # SECURITY: Uses AST-based evaluator instead of eval() to prevent code injection
+                tree = ast.parse(expr, mode="eval")
+                return lambda *_a, **_kw: _safe_eval_ast(tree)
             # Default: identity (return args as-is)
             return lambda *a, **kw: {"args": a, "kwargs": kw}
 

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -165,7 +165,9 @@ def orchestrator_run_dag(
                     ast.UAdd: operator.pos,
                 }
 
-                def _safe_eval_ast(node: ast.AST) -> float:
+                from typing import Any
+
+                def _safe_eval_ast(node: ast.AST) -> Any:
                     """Recursively evaluate an AST node containing only arithmetic and specific functions."""
                     if isinstance(node, ast.Expression):
                         return _safe_eval_ast(node.body)


### PR DESCRIPTION
This pull request replaces the insecure `eval()` call in `orchestrator_run_dag` with a secure Abstract Syntax Tree (AST) parser (`ast.parse()`). The AST-based evaluator securely processes the `fn_expr` parameter and restricts execution only to explicitly whitelisted literal values, binary operations, unary operations, and the exact set of functions listed in `safe_locals`. This entirely removes the risk of arbitrary code execution that existed despite previous sandbox attempts (e.g. `__builtins__: {}` and blocking double underscores).

It also adds a new journal entry to `.jules/sentinel.md` documenting this finding and the mitigation strategy.

---
*PR created automatically by Jules for task [17116615232841529251](https://jules.google.com/task/17116615232841529251) started by @docxology*