### PR TITLE
⚡ Bolt: Optimize MD5 digest to int conversion in MinHash shingling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,7 @@
 **Vulnerability/Performance Issue:** Synchronous blocking `time.sleep` calls were present in retry loops during API interaction logic. When the framework executes in an event loop environment, these synchronous blocking calls could stall the event loop. Furthermore, maintaining split implementation blocks (sync vs async) introduced duplication and bugs.
 **Learning:** `asyncio.run()` cannot be called when an event loop is already running. For unified API endpoints needing sync wrappers that might be called within existing asyncio event loops, standard practice is to use a ThreadPoolExecutor wrapper (`pool.submit(asyncio.run, coro).result()`) to isolate the new loop from the running one, thus preventing `RuntimeError: asyncio.run() cannot be called from a running event loop`.
 **Prevention:** Avoid split sync/async codebase logic if async wrappers or pure async calls are sufficient. Always test sync-wrapper methods in an event loop environment (e.g., using `pytest.mark.asyncio`) to catch runtime boundary errors.
+
+## 2024-05-17 - Python hashlib performance optimization
+**Learning:** Extracting integer values from `hashlib` digests in Python via string representation (`int(hashlib.md5(...).hexdigest(), 16)`) introduces significant string allocation and parsing overhead.
+**Action:** Use `int.from_bytes(hashlib.md5(...).digest(), 'big')` instead for a more efficient conversion that preserves the exact numeric values.

--- a/src/codomyrmex/data_curation/minhash.py
+++ b/src/codomyrmex/data_curation/minhash.py
@@ -41,8 +41,10 @@ class MinHash:
         for i in range(len(text) - self.shingle_size + 1):
             shingle = text[i : i + self.shingle_size]
             h = (
-                int(
-                    hashlib.md5(shingle.encode(), usedforsecurity=False).hexdigest(), 16
+                # ⚡ Bolt: Using int.from_bytes(digest) instead of int(hexdigest(), 16)
+                # avoids string allocation and base-16 parsing overhead.
+                int.from_bytes(
+                    hashlib.md5(shingle.encode(), usedforsecurity=False).digest(), "big"
                 )
                 % self._p
             )


### PR DESCRIPTION
💡 What: Replaced string `.hexdigest()` parsing with direct bytes-to-int conversion using `int.from_bytes(..., 'big')` in `src/codomyrmex/data_curation/minhash.py`.
🎯 Why: `hexdigest()` converts binary digest data into a string that is then base-16 parsed back into a Python integer. Skipping the string translation saves memory allocation and parsing overhead in tight string shingling loops.
📊 Impact: Eliminates redundant string allocations and hex-decoding computations during shingle hashing, improving overall data curation runtime slightly.
🔬 Measurement: Verify backward compatibility by ensuring `tests/unit/data_curation/` tests pass perfectly.

---
*PR created automatically by Jules for task [7914385860776754304](https://jules.google.com/task/7914385860776754304) started by @docxology*