### PR TITLE
test: add unit test for hardware info profiler

### DIFF
--- a/src/codomyrmex/tests/unit/system_discovery/test_profilers.py
+++ b/src/codomyrmex/tests/unit/system_discovery/test_profilers.py
@@ -1,0 +1,48 @@
+"""Tests for hardware and environment profilers."""
+
+import pytest
+
+from codomyrmex.system_discovery.reporting.profilers import HardwareProfiler
+
+
+@pytest.mark.unit
+class TestHardwareProfiler:
+    """Tests for HardwareProfiler."""
+
+    def test_get_hardware_info(self):
+        """Test getting hardware info returns expected keys and types."""
+        info = HardwareProfiler.get_hardware_info()
+
+        # Should be a dictionary
+        assert isinstance(info, dict)
+
+        # Base keys
+        assert "cpu_count" in info
+        assert "cpu_threads" in info
+        assert "os" in info
+        assert "os_release" in info
+        assert "os_version" in info
+        assert "architecture" in info
+        assert "processor" in info
+        assert "gpu" in info
+
+        # Optional keys based on psutil availability
+        assert "cpu_freq" in info
+        assert "total_ram_gb" in info
+        assert "available_ram_gb" in info
+
+        # Type checks
+        assert isinstance(info["cpu_count"], (int, type(None)))
+        assert isinstance(info["cpu_threads"], (int, type(None)))
+        assert isinstance(info["os"], str)
+        assert isinstance(info["os_release"], str)
+        assert isinstance(info["os_version"], str)
+        assert isinstance(info["architecture"], str)
+        assert isinstance(info["processor"], str)
+        assert isinstance(info["gpu"], dict)
+        assert "available" in info["gpu"]
+        assert "details" in info["gpu"]
+
+        assert isinstance(info["cpu_freq"], (dict, type(None)))
+        assert isinstance(info["total_ram_gb"], (float, int, type(None)))
+        assert isinstance(info["available_ram_gb"], (float, int, type(None)))


### PR DESCRIPTION
🎯 **What:** The testing gap for `HardwareProfiler.get_hardware_info()` in `src/codomyrmex/system_discovery/reporting/profilers.py` was addressed by creating a dedicated test file.
📊 **Coverage:** The test covers the happy path by executing the profiler and verifying the returned dictionary structure, specifically checking for the presence of base keys (`cpu_count`, `os`, `architecture`, etc.), optional keys (`cpu_freq`, `total_ram_gb`, etc.), and enforcing basic type constraints on the returned values.
✨ **Result:** Increased test coverage for system discovery profilers without using restricted mocking utilities.

---
*PR created automatically by Jules for task [15899788456583821697](https://jules.google.com/task/15899788456583821697) started by @docxology*