### PR TITLE
test: add unit test for get_event_stats in event_logger

### DIFF
--- a/src/codomyrmex/tests/unit/events/test_events_comprehensive.py
+++ b/src/codomyrmex/tests/unit/events/test_events_comprehensive.py
@@ -937,6 +937,28 @@ class TestEventLoggerExtended:
 
         assert len(recent) <= 5
 
+    def test_get_event_stats_returns_singleton_stats(self):
+        """get_event_stats() correctly returns statistics from the singleton EventLogger."""
+        from codomyrmex.events.handlers.event_logger import (
+            get_event_logger,
+            get_event_stats,
+            log_event_to_monitoring,
+        )
+
+        logger = get_event_logger()
+        logger.clear()
+
+        try:
+            event = Event(event_type=EventType.SYSTEM_STARTUP, source="test")
+            log_event_to_monitoring(event)
+
+            stats = get_event_stats()
+
+            assert stats["total_events"] == 1
+            assert stats["event_counts"][EventType.SYSTEM_STARTUP.value] == 1
+        finally:
+            logger.clear()
+
 
 # ===========================================================================
 # AsyncStream (async_stream.py)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The global `get_event_stats()` function in `codomyrmex/events/handlers/event_logger.py` was previously uncovered in the test suite, lacking validation of its ability to query the internal singleton `EventLogger`.

📊 **Coverage:** What scenarios are now tested
A new test `test_get_event_stats_returns_singleton_stats` has been added. It tests:
1. Clearing the singleton logger.
2. Emitting an event (e.g. `SYSTEM_STARTUP`) to the logger via `log_event_to_monitoring`.
3. Verifying that the `get_event_stats()` dictionary has accurate `total_events` count and specifically tracks the event type logged.
4. Ensuring isolated states by calling `logger.clear()` via a `finally` block.

✨ **Result:** The improvement in test coverage
`get_event_stats` is properly tested using `TestEventLoggerExtended` in the `test_events_comprehensive.py` test suite, adhering to the project's zero-mock requirements while robustly ensuring reliable stat retrieval functionality without test pollution.

---
*PR created automatically by Jules for task [2735940982771684916](https://jules.google.com/task/2735940982771684916) started by @docxology*