### PR TITLE
test: add health checker git status tests

### DIFF
--- a/src/codomyrmex/tests/unit/system_discovery/test_capability_scanner.py
+++ b/src/codomyrmex/tests/unit/system_discovery/test_capability_scanner.py
@@ -133,8 +133,9 @@ CONSTANT = 42
         assert len(classes) >= 1
 
     def test_scan_all_modules(self):
+        project_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
         scanner = CapabilityScanner(
-            project_root=Path("/Users/mini/Documents/GitHub/codomyrmex")
+            project_root=project_root
         )
         modules = scanner.scan_all_modules()
         assert isinstance(modules, dict)

--- a/src/codomyrmex/tests/unit/system_discovery/test_health_checker.py
+++ b/src/codomyrmex/tests/unit/system_discovery/test_health_checker.py
@@ -1,0 +1,116 @@
+"""Tests for codomyrmex.system_discovery.core.health_checker module.
+
+Covers:
+- SystemHealthChecker.check_git_status (zero-mock policy applied)
+"""
+
+import subprocess
+
+import pytest
+
+from codomyrmex.system_discovery.core.health_checker import SystemHealthChecker
+
+
+@pytest.mark.unit
+class TestSystemHealthCheckerGitStatus:
+    """Test the check_git_status method."""
+
+    def test_not_a_git_repo(self, tmp_path, capsys):
+        """Test output when directory is not a Git repository."""
+        checker = SystemHealthChecker(tmp_path, tmp_path / "src", tmp_path / "tests")
+        checker.check_git_status()
+        out, _ = capsys.readouterr()
+        assert "Not a git repository" in out
+
+    def test_git_not_found(self, tmp_path, capsys, monkeypatch):
+        """Test output when git command is not found in PATH."""
+        monkeypatch.setenv("PATH", "")
+        checker = SystemHealthChecker(tmp_path, tmp_path / "src", tmp_path / "tests")
+        checker.check_git_status()
+        out, _ = capsys.readouterr()
+        assert "Git not found" in out
+
+    def test_git_repo_clean(self, tmp_path, capsys):
+        """Test output when in a clean Git repository."""
+        # Initialize a real git repo
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # Create a commit so we have a clean working tree and a current branch
+        (tmp_path / "file.txt").write_text("hello")
+        subprocess.run(
+            ["git", "add", "file.txt"], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # Ensure we're on a known branch name to test output parsing
+        subprocess.run(
+            ["git", "branch", "-M", "main"],
+            cwd=tmp_path,
+            check=False,
+            capture_output=True,
+        )
+
+        checker = SystemHealthChecker(tmp_path, tmp_path / "src", tmp_path / "tests")
+        checker.check_git_status()
+        out, _ = capsys.readouterr()
+
+        assert "Git repository initialized" in out
+        assert "Working tree clean" in out
+        assert "Current branch: main" in out
+
+    def test_git_repo_uncommitted_changes(self, tmp_path, capsys):
+        """Test output when Git repository has uncommitted changes."""
+        # Initialize a real git repo
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # Create a commit
+        (tmp_path / "file.txt").write_text("hello")
+        subprocess.run(
+            ["git", "add", "file.txt"], cwd=tmp_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # Create uncommitted changes (one new file, one modified file)
+        (tmp_path / "file2.txt").write_text("hello2")
+        (tmp_path / "file.txt").write_text("modified")
+
+        checker = SystemHealthChecker(tmp_path, tmp_path / "src", tmp_path / "tests")
+        checker.check_git_status()
+        out, _ = capsys.readouterr()
+
+        assert "Git repository initialized" in out
+        assert "2 uncommitted changes" in out


### PR DESCRIPTION
🎯 **What:** This PR introduces tests for `SystemHealthChecker.check_git_status` inside `src/codomyrmex/system_discovery/core/health_checker.py`. In strict compliance with the codebase's zero-mock policy, it provisions real local git repositories inside pytest temporary directories to ensure realistic coverage.
📊 **Coverage:** The new test cases cover:
- Checking a non-git directory (`test_not_a_git_repo`)
- Handling an absent git binary via PATH manipulation (`test_git_not_found`)
- Parsing output from a clean git repository (`test_git_repo_clean`)
- Parsing output when there are uncommitted and untracked changes (`test_git_repo_uncommitted_changes`)
✨ **Result:** Enhanced regression coverage for Git health checks. Additionally, it contains a minor fix to an adjacent unit test that was previously failing due to a hardcoded developer path (`/Users/mini/...`).

---
*PR created automatically by Jules for task [17483831831312376465](https://jules.google.com/task/17483831831312376465) started by @docxology*