### PR TITLE
fix: resolve SQL injection vulnerability in database manager

### DIFF
--- a/src/codomyrmex/database_management/db_manager.py
+++ b/src/codomyrmex/database_management/db_manager.py
@@ -344,10 +344,9 @@ class DatabaseManager:
             raise CodomyrmexError("No database connection available")
 
         if conn.db_type == DatabaseType.SQLITE:
-            # Escape the identifier by replacing " with "" and wrapping in double quotes
-            escaped_table_name = table_name.replace('"', '""')
-            safe_table_name = f'"{escaped_table_name}"'
-            result = conn.execute(f"PRAGMA table_info({safe_table_name})")
+            # Use parameterized query with pragma_table_info table-valued function
+            # to prevent SQL injection vulnerabilities.
+            result = conn.execute("SELECT * FROM pragma_table_info(?)", (table_name,))
             columns = []
             for row in result.rows:
                 columns.append(


### PR DESCRIPTION
🎯 **What:** Fixed a potential SQL injection vulnerability in `DatabaseManager.get_table_info`.
⚠️ **Risk:** The previous implementation formatted user-supplied table names directly into a `PRAGMA table_info()` string query. While the input was naively escaped (by doubling double quotes), string formatting in SQL queries is an anti-pattern and can lead to SQL injection vulnerabilities depending on how the input is crafted or validated upstream. This could potentially allow an attacker to bypass the intended table inspection and execute arbitrary PRAGMA statements or other queries.
🛡️ **Solution:** Replaced the unsafe string interpolation with the secure table-valued function equivalent `SELECT * FROM pragma_table_info(?)`, which properly supports parameterized queries in SQLite. This natively mitigates the injection vector while maintaining exact behavioral equivalence in the parsed output.

---
*PR created automatically by Jules for task [9557231547899354204](https://jules.google.com/task/9557231547899354204) started by @docxology*