### PR TITLE
🔒 fix: prevent command injection in deployment hooks

### DIFF
--- a/src/codomyrmex/ci_cd_automation/deployment_orchestrator.py
+++ b/src/codomyrmex/ci_cd_automation/deployment_orchestrator.py
@@ -8,6 +8,7 @@ and release coordination capabilities.
 import importlib
 import json
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -562,9 +563,11 @@ class DeploymentOrchestrator:
                 env.update(deployment.environment.variables)
                 env["DEPLOYMENT_VERSION"] = deployment.version
 
+                command = hook if os.name == "nt" else shlex.split(hook)
+
                 result = subprocess.run(
-                    hook,
-                    shell=True,
+                    command,
+                    shell=False,
                     capture_output=True,
                     text=True,
                     cwd=os.getcwd(),

--- a/src/codomyrmex/tests/unit/ci_cd_automation/test_ci_cd_core.py
+++ b/src/codomyrmex/tests/unit/ci_cd_automation/test_ci_cd_core.py
@@ -128,7 +128,7 @@ class TestDeploymentStatusEnum:
 
     @pytest.mark.unit
     def test_deployment_status_member_count(self):
-        assert len(DeploymentStatus) == 9
+        assert len(DeploymentStatus) == 10
 
 
 class TestEnvironmentTypeEnum:

--- a/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator.py
+++ b/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator.py
@@ -96,6 +96,7 @@ class TestDeploymentStatusEnum:
             "IN_PROGRESS",
             "DEPLOYED",
             "ROLLING_BACK",
+            "FAILED",
         }
         assert set(DeploymentStatus.__members__.keys()) == expected
 

--- a/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator_comprehensive.py
+++ b/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator_comprehensive.py
@@ -59,7 +59,7 @@ class TestDeploymentOrchestrator:
         """Test deployment with a failing pre-deploy hook."""
         orchestrator = DeploymentOrchestrator(config_file)
         env = orchestrator.environments["staging"]
-        env.pre_deploy_hooks = ["exit 1"]
+        env.pre_deploy_hooks = ["false"]
 
         deployment = orchestrator.create_deployment("fail-hook", "1.0", "staging", [])
         # We don't rollback if it's not a real failure during deployment itself

--- a/src/codomyrmex/tests/unit/ci_cd_automation/test_pipeline_manager.py
+++ b/src/codomyrmex/tests/unit/ci_cd_automation/test_pipeline_manager.py
@@ -549,7 +549,10 @@ class TestCancelPipeline:
         try:
 
             async def _dummy():
-                await asyncio.sleep(100)
+                try:
+                    await asyncio.sleep(100)
+                except asyncio.CancelledError:
+                    pass
 
             task = loop.create_task(_dummy())
             mgr.active_executions["test_pipeline"] = task
@@ -560,6 +563,10 @@ class TestCancelPipeline:
             # "cancelled" after the event loop processes it. Verify cancel
             # was requested:
             assert task.cancelling() > 0 or task.cancelled()
+            try:
+                loop.run_until_complete(task)
+            except asyncio.CancelledError:
+                pass
         finally:
             loop.close()
 


### PR DESCRIPTION
🎯 **What:** Removed shell=True in _execute_hooks for subprocess.run.
⚠️ **Risk:** Arbitrary command execution by malicious or misconfigured hooks.
🛡️ **Solution:** Parsed hook strings via shlex.split on POSIX systems or passed as a string on Windows, and set shell=False. Additionally fixed related test case issues to maintain CI integrity.

---
*PR created automatically by Jules for task [18403522375766472970](https://jules.google.com/task/18403522375766472970) started by @docxology*