### PR TITLE
perf: eliminate redundant AST parse for __init__ scanning

### DIFF
--- a/src/codomyrmex/system_discovery/module_introspector.py
+++ b/src/codomyrmex/system_discovery/module_introspector.py
@@ -122,11 +122,23 @@ class ModuleIntrospector:
                 mcp_count += content.count("@mcp_tool")
 
                 tree = ast.parse(content, filename=str(f))
+                is_main_init = f == mod_dir / "__init__.py"
+
                 for node in ast.walk(tree):
                     if isinstance(node, ast.ClassDef):
                         total_classes += 1
                     elif isinstance(node, ast.FunctionDef) and node.col_offset == 0:
                         total_functions += 1
+                    elif is_main_init and isinstance(node, ast.Assign):
+                        for target in node.targets:
+                            if isinstance(target, ast.Name) and target.id == "__all__":
+                                if isinstance(node.value, ast.List):
+                                    info.exports = [
+                                        elt.value
+                                        for elt in node.value.elts
+                                        if isinstance(elt, ast.Constant)
+                                        and isinstance(elt.value, str)
+                                    ]
             except Exception:
                 continue
 
@@ -142,25 +154,6 @@ class ModuleIntrospector:
 
         # Test detection
         info.has_tests = bool(list(mod_dir.rglob("test_*.py")))
-
-        # Exports from __init__.py
-        init_path = mod_dir / "__init__.py"
-        if init_path.exists():
-            try:
-                tree = ast.parse(init_path.read_text(errors="replace"))
-                for node in ast.walk(tree):
-                    if isinstance(node, ast.Assign):
-                        for target in node.targets:
-                            if isinstance(target, ast.Name) and target.id == "__all__":
-                                if isinstance(node.value, ast.List):
-                                    info.exports = [
-                                        elt.value
-                                        for elt in node.value.elts
-                                        if isinstance(elt, ast.Constant)
-                                        and isinstance(elt.value, str)
-                                    ]
-            except Exception:
-                pass
 
         # Submodule counting
         info.submodule_count = sum(


### PR DESCRIPTION
💡 **What:** The optimization moves the detection logic of `__all__` exports for `__init__.py` files inside the general `ast.walk()` iterator block that traverses all python files. It conditionally acts on `is_main_init` checking.
🎯 **Why:** To eliminate the secondary `ast.parse` and `ast.walk` overhead dedicated solely to extracting `__all__` declarations out of top-level `__init__.py` files when scanning modules.
📊 **Measured Improvement:** The module introspector scan baseline was ~51.6s for 5 scans in the benchmark script. After optimization, it hovered identically at ~51.6s. The measured performance impact is minor (within margin of error) since `__init__.py` comprises a very small subset of overall source lines being parsed. However, mathematically speaking, removing the entire secondary parser loop structurally eliminates redundant `O(n)` AST traversals where `n` is the nodes in the init file, strictly improving execution profiles.

---
*PR created automatically by Jules for task [2046127234667206253](https://jules.google.com/task/2046127234667206253) started by @docxology*