### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in CI/CD hooks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,14 @@ Duplicate definitions across modules (e.g., repeating the `SecretType` definitio
 
 **Prevention:**
 Use descriptive suffixes or alternatives (e.g., changing `"password"` to `"password_type"`) for model or type definitions. Implement robust CI checks to enforce single-source-of-truth patterns rather than duplicating classes.
+
+## 2026-03-01 - Fix Command Injection in subprocess calls
+
+**Vulnerability:**
+The `_execute_hooks` method in `src/codomyrmex/ci_cd_automation/deployment_orchestrator.py` executed CI/CD deployment hooks (user-provided or configuration-provided strings) using `subprocess.run(hook, shell=True)`. This represents a severe command injection vulnerability because a malicious actor could embed arbitrary shell commands (e.g., `hook = "echo hello; rm -rf /"`).
+
+**Learning:**
+Even within internal orchestration tools or deployment workflows, strings passed to subprocess should never use `shell=True` unless strictly necessary and perfectly sanitized. Refactoring from `shell=True` to `shell=False` requires handling shell built-ins in tests (e.g. replacing `exit 1` with `false`).
+
+**Prevention:**
+Always use `shell=False`. When dealing with raw command strings that need to be executed cross-platform, handle Windows appropriately (`cmd = hook` if `os.name == 'nt'`) and use `shlex.split(hook)` on POSIX systems to securely parse the string into an argument list before passing it to `subprocess.run()`.

--- a/src/codomyrmex/ci_cd_automation/deployment_orchestrator.py
+++ b/src/codomyrmex/ci_cd_automation/deployment_orchestrator.py
@@ -8,6 +8,7 @@ and release coordination capabilities.
 import importlib
 import json
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -562,9 +563,12 @@ class DeploymentOrchestrator:
                 env.update(deployment.environment.variables)
                 env["DEPLOYMENT_VERSION"] = deployment.version
 
+                # SECURITY: Mitigate command injection in deployment hooks
+                cmd = hook if os.name == "nt" else shlex.split(hook)
+
                 result = subprocess.run(
-                    hook,
-                    shell=True,
+                    cmd,
+                    shell=False,
                     capture_output=True,
                     text=True,
                     cwd=os.getcwd(),

--- a/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator_comprehensive.py
+++ b/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator_comprehensive.py
@@ -59,7 +59,7 @@ class TestDeploymentOrchestrator:
         """Test deployment with a failing pre-deploy hook."""
         orchestrator = DeploymentOrchestrator(config_file)
         env = orchestrator.environments["staging"]
-        env.pre_deploy_hooks = ["exit 1"]
+        env.pre_deploy_hooks = ["false"]
 
         deployment = orchestrator.create_deployment("fail-hook", "1.0", "staging", [])
         # We don't rollback if it's not a real failure during deployment itself


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_execute_hooks` method in `DeploymentOrchestrator` passed user-configurable webhook strings to `subprocess.run` with `shell=True`, allowing for command injection.
🎯 Impact: A malicious actor configuring the pipeline could gain unauthorized shell access and execute arbitrary commands on the runner.
🔧 Fix: Replaced `shell=True` with `shell=False`. Handled string parsing dynamically by passing strings for Windows (`os.name == 'nt'`) and properly sanitizing POSIX strings using `shlex.split`. Replaced `exit 1` in tests with `false` to account for shell built-in differences.
✅ Verification: Ran `uv run ruff check` and full unit test suite `uv run pytest src/codomyrmex/tests/unit/ci_cd_automation/`.

---
*PR created automatically by Jules for task [7690862193749611179](https://jules.google.com/task/7690862193749611179) started by @docxology*