### PR TITLE
⚡ Bolt: perf: replace hexdigest string conversion with digest byte extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -3,3 +3,8 @@
 **Vulnerability/Performance Issue:** Synchronous blocking `time.sleep` calls were present in retry loops during API interaction logic. When the framework executes in an event loop environment, these synchronous blocking calls could stall the event loop. Furthermore, maintaining split implementation blocks (sync vs async) introduced duplication and bugs.
 **Learning:** `asyncio.run()` cannot be called when an event loop is already running. For unified API endpoints needing sync wrappers that might be called within existing asyncio event loops, standard practice is to use a ThreadPoolExecutor wrapper (`pool.submit(asyncio.run, coro).result()`) to isolate the new loop from the running one, thus preventing `RuntimeError: asyncio.run() cannot be called from a running event loop`.
 **Prevention:** Avoid split sync/async codebase logic if async wrappers or pure async calls are sufficient. Always test sync-wrapper methods in an event loop environment (e.g., using `pytest.mark.asyncio`) to catch runtime boundary errors.
+
+## 2024-05-18 - Replacing hexdigest() with digest() for integer hashing
+
+**Learning:** When converting a `hashlib` digest into an integer (e.g., for consistent hashing or deterministic bucket assignment), converting `.hexdigest()` to a string and then parsing it as base-16 via `int(..., 16)` introduces unnecessary overhead from string allocation and base parsing.
+**Action:** Extract integer values directly from the bytes object using `int.from_bytes(digest(), 'big')` instead of `int(hexdigest(), 16)` to optimize hashing logic that executes frequently or in tight loops.

--- a/src/codomyrmex/feature_flags/experiments.py
+++ b/src/codomyrmex/feature_flags/experiments.py
@@ -164,7 +164,7 @@ class ExperimentManager:
         """Assign user to variant deterministically."""
         # Hash user_id + experiment_id for deterministic assignment
         hash_input = f"{experiment.id}:{user_id}"
-        hash_value = int(hashlib.sha256(hash_input.encode()).hexdigest(), 16)
+        hash_value = int.from_bytes(hashlib.sha256(hash_input.encode()).digest(), "big")
         bucket = (hash_value % 10000) / 10000.0
 
         cumulative = 0.0
@@ -183,7 +183,7 @@ class ExperimentManager:
     ) -> bool:
         """Check if user is in experiment traffic."""
         hash_input = f"{experiment_id}:traffic:{user_id}"
-        hash_value = int(hashlib.sha256(hash_input.encode()).hexdigest(), 16)
+        hash_value = int.from_bytes(hashlib.sha256(hash_input.encode()).digest(), "big")
         bucket = (hash_value % 10000) / 100.0
         return bucket < percentage
 

--- a/src/codomyrmex/utils/hashing.py
+++ b/src/codomyrmex/utils/hashing.py
@@ -62,7 +62,9 @@ class ConsistentHash:
 
     def _hash(self, key: str) -> int:
         """Return the hash value."""
-        return int(hashlib.md5(key.encode(), usedforsecurity=False).hexdigest(), 16)
+        return int.from_bytes(
+            hashlib.md5(key.encode(), usedforsecurity=False).digest(), "big"
+        )
 
     def add_node(self, node: str) -> None:
         """Add a node to the ring."""


### PR DESCRIPTION
💡 What: Replaced `int(hashlib...hexdigest(), 16)` with `int.from_bytes(hashlib...digest(), 'big')` across the repository.
🎯 Why: Converting `.hexdigest()` to a string and parsing it as base-16 introduces unnecessary memory allocations and parsing overhead. Extracting the integer directly from the byte object is mathematically equivalent but substantially faster and more efficient, which is crucial for hashing algorithms executed frequently or in tight deterministic loops.
📊 Impact: Reduces computational overhead and memory allocation significantly on core hashing functions without altering the resulting deterministic output.
🔬 Measurement: Verify tests continue to pass (verified via `uv run pytest src/codomyrmex/tests/unit/feature_flags/test_experiments.py src/codomyrmex/tests/unit/utils/test_utils_hashing.py`) and check `.jules/bolt.md` for documented learnings.

---
*PR created automatically by Jules for task [3453661898010323747](https://jules.google.com/task/3453661898010323747) started by @docxology*