### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval() sandbox escape vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@ Duplicate definitions across modules (e.g., repeating the `SecretType` definitio
 
 **Prevention:**
 Use descriptive suffixes or alternatives (e.g., changing `"password"` to `"password_type"`) for model or type definitions. Implement robust CI checks to enforce single-source-of-truth patterns rather than duplicating classes.
+
+## 2024-05-18 - Prevent Command Injection via eval() Sandbox Escape
+**Vulnerability:** Found `eval(expr, {"__builtins__": {}}, safe_locals)` in `orchestrator_run_dag` (MCP tool). Even with an empty `__builtins__` dict, `eval()` allows sandbox escapes by walking the type hierarchy to retrieve `__builtins__` from other loaded modules (e.g., `[x for x in ().__class__.__base__.__subclasses__() if x.__name__ == 'type'][0]('__import__', (), {})('os').system('cmd')`).
+**Learning:** `eval()` is never safe for untrusted user input, even with limited `globals()`/`locals()` dicts. Python's object model is too reflective.
+**Prevention:** Always use AST parsing (e.g. `ast.parse` with a recursive AST node evaluator) for executing dynamic Python expressions, limiting allowed node types explicitly.

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -145,9 +145,7 @@ def orchestrator_run_dag(
                 import ast
                 import operator
 
-                def _safe_eval(
-                    node: ast.AST,
-                ) -> float | int | str | list | dict | tuple | set:
+                def _safe_eval(node: ast.AST) -> float | int | str | list | dict | tuple | set:
                     if isinstance(node, ast.Expression):
                         return _safe_eval(node.body)
                     if isinstance(node, ast.Constant):

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -142,15 +142,92 @@ def orchestrator_run_dag(
                         "Double underscores are not allowed in fn_expr for security reasons."
                     )
 
-                safe_locals = {
-                    "len": len,
-                    "sum": sum,
-                    "min": min,
-                    "max": max,
-                    "abs": abs,
-                    "round": round,
-                }
-                return lambda *_a, **_kw: eval(expr, {"__builtins__": {}}, safe_locals)
+                import ast
+                import operator
+
+                def _safe_eval(
+                    node: ast.AST,
+                ) -> float | int | str | list | dict | tuple | set:
+                    if isinstance(node, ast.Expression):
+                        return _safe_eval(node.body)
+                    if isinstance(node, ast.Constant):
+                        return node.value
+                    if isinstance(node, ast.List):
+                        return [_safe_eval(x) for x in node.elts]
+                    if isinstance(node, ast.Tuple):
+                        return tuple(_safe_eval(x) for x in node.elts)
+                    if isinstance(node, ast.Set):
+                        return {_safe_eval(x) for x in node.elts}
+                    if isinstance(node, ast.Dict):
+                        return {
+                            _safe_eval(k): _safe_eval(v)
+                            for k, v in zip(node.keys, node.values, strict=False)
+                        }
+
+                    if isinstance(node, ast.Name):
+                        safe_funcs = {
+                            "len": len,
+                            "sum": sum,
+                            "min": min,
+                            "max": max,
+                            "abs": abs,
+                            "round": round,
+                        }
+                        if node.id in safe_funcs:
+                            return safe_funcs[node.id]
+                        raise ValueError(f"Unknown variable: {node.id}")
+
+                    _math_ops = {
+                        ast.Add: operator.add,
+                        ast.Sub: operator.sub,
+                        ast.Mult: operator.mul,
+                        ast.Div: operator.truediv,
+                        ast.USub: operator.neg,
+                        ast.UAdd: operator.pos,
+                    }
+                    if isinstance(node, ast.BinOp) and type(node.op) in _math_ops:
+                        return _math_ops[type(node.op)](
+                            _safe_eval(node.left), _safe_eval(node.right)
+                        )
+                    if isinstance(node, ast.UnaryOp) and type(node.op) in _math_ops:
+                        return _math_ops[type(node.op)](_safe_eval(node.operand))
+
+                    _compare_ops = {
+                        ast.Eq: operator.eq,
+                        ast.NotEq: operator.ne,
+                        ast.Lt: operator.lt,
+                        ast.LtE: operator.le,
+                        ast.Gt: operator.gt,
+                        ast.GtE: operator.ge,
+                    }
+                    if (
+                        isinstance(node, ast.Compare)
+                        and len(node.ops) == 1
+                        and len(node.comparators) == 1
+                    ):
+                        op = type(node.ops[0])
+                        if op in _compare_ops:
+                            return _compare_ops[op](
+                                _safe_eval(node.left), _safe_eval(node.comparators[0])
+                            )
+
+                    if isinstance(node, ast.Call):
+                        if isinstance(node.func, ast.Name):
+                            safe_funcs = {
+                                "len": len,
+                                "sum": sum,
+                                "min": min,
+                                "max": max,
+                                "abs": abs,
+                                "round": round,
+                            }
+                            if node.func.id in safe_funcs:
+                                args = [_safe_eval(arg) for arg in node.args]
+                                return safe_funcs[node.func.id](*args)
+
+                    raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+                return lambda *_a, **_kw: _safe_eval(ast.parse(expr, mode="eval"))
             # Default: identity (return args as-is)
             return lambda *a, **kw: {"args": a, "kwargs": kw}
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `orchestrator_run_dag` MCP tool used `eval(expr, {"__builtins__": {}}, safe_locals)` to evaluate task expressions. Even with an empty `__builtins__` dict, `eval()` is vulnerable to sandbox escapes via Python's object model (e.g., extracting `__builtins__` through `().__class__.__base__.__subclasses__()`).
🎯 **Impact:** Attackers could execute arbitrary shell commands or code on the host system running the orchestrator agent by passing specially crafted malicious payloads as task expressions.
🔧 **Fix:** Replaced `eval()` with `ast.parse` and a strict recursive `_safe_eval` function that only allows safe literals, math/comparison operations, list/dict/tuple/set creation, and a strict whitelist of safe functions (`len`, `sum`, `min`, `max`, `abs`, `round`).
✅ **Verification:** Ran `uv run pytest src/codomyrmex/tests/unit/orchestrator/test_agent_orchestrator_extended.py` to confirm `test_orchestrator_run_dag_safe_eval_blocks_malicious_code` passes along with other unit tests. Formatted and linted with `ruff`.

---
*PR created automatically by Jules for task [9897990665972943594](https://jules.google.com/task/9897990665972943594) started by @docxology*