### PR TITLE
🧪 test: add unit tests for list_cloud_instances in cloud mcp tools

### DIFF
--- a/scripts/demos/demo_defense.py
+++ b/scripts/demos/demo_defense.py
@@ -15,6 +15,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent / "src"))
 
 from codomyrmex.defense import ActiveDefense, RabbitHole
+
 from codomyrmex.utils.cli_helpers import (
     print_error,
     print_info,

--- a/scripts/verification/verify_phase2.py
+++ b/scripts/verification/verify_phase2.py
@@ -10,6 +10,7 @@ Verifies Defense and Market module functionality:
 """
 
 from codomyrmex.defense import ActiveDefense, RabbitHole
+
 from codomyrmex.market import DemandAggregator, ReverseAuction
 
 

--- a/src/codomyrmex/tests/unit/cloud/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/cloud/test_mcp_tools.py
@@ -1,0 +1,80 @@
+import pytest
+from _stubs import Stub
+
+from codomyrmex.cloud.mcp_tools import list_cloud_instances
+
+
+def test_list_cloud_instances_success(monkeypatch):
+    """Test successful listing of cloud instances."""
+
+    # Create a mock instance
+    mock_instance_1 = Stub()
+    mock_instance_1.id = "inst-1"
+    mock_instance_1.name = "web-server"
+    mock_instance_1.status = "ACTIVE"
+    mock_instance_1.flavor = {"original_name": "g1-small"}
+
+    mock_instance_2 = Stub()
+    mock_instance_2.id = "inst-2"
+    mock_instance_2.name = "db-server"
+    mock_instance_2.status = "STOPPED"
+    # Test the fallback flavor case
+    mock_instance_2.flavor = "g1-large"
+
+    # Setup the mock client
+    mock_client = Stub()
+    mock_client.list_instances.return_value = [mock_instance_1, mock_instance_2]
+
+    mock_client_class = Stub()
+    mock_client_class.from_env.return_value = mock_client
+
+    monkeypatch.setattr(
+        "codomyrmex.cloud.infomaniak.InfomaniakComputeClient.from_env",
+        mock_client_class.from_env,
+    )
+
+    # Call the tool
+    result = list_cloud_instances()
+
+    # Verify calls
+    mock_client_class.from_env.assert_called_once()
+    mock_client.list_instances.assert_called_once()
+
+    # Verify results
+    assert result["status"] == "success"
+    assert result["count"] == 2
+    assert len(result["instances"]) == 2
+
+    # Check first instance
+    assert result["instances"][0]["id"] == "inst-1"
+    assert result["instances"][0]["name"] == "web-server"
+    assert result["instances"][0]["status"] == "ACTIVE"
+    assert result["instances"][0]["flavor"] == "g1-small"
+
+    # Check second instance with fallback flavor
+    assert result["instances"][1]["id"] == "inst-2"
+    assert result["instances"][1]["flavor"] == "g1-large"
+
+
+def test_list_cloud_instances_error(monkeypatch):
+    """Test error handling in listing cloud instances."""
+
+    # Setup the mock client to raise an exception
+    mock_client_class = Stub()
+    mock_client_class.from_env.side_effect = Exception("API Error")
+
+    monkeypatch.setattr(
+        "codomyrmex.cloud.infomaniak.InfomaniakComputeClient.from_env",
+        mock_client_class.from_env,
+    )
+
+    # Call the tool
+    result = list_cloud_instances()
+
+    # Verify calls
+    mock_client_class.from_env.assert_called_once()
+
+    # Verify error result
+    assert result["status"] == "error"
+    assert "Failed to list instances" in result["message"]
+    assert "API Error" in result["message"]

--- a/src/codomyrmex/tests/unit/defense/test_defense.py
+++ b/src/codomyrmex/tests/unit/defense/test_defense.py
@@ -1,7 +1,6 @@
 """Comprehensive zero-mock tests for the defense module."""
 
 import pytest
-
 from codomyrmex.defense import (
     ActiveDefense,
     Defense,

--- a/src/codomyrmex/tests/unit/defense/test_defense_core.py
+++ b/src/codomyrmex/tests/unit/defense/test_defense_core.py
@@ -3,7 +3,6 @@
 import time
 
 import pytest
-
 from codomyrmex.defense.defense import (
     Defense,
     DetectionRule,

--- a/src/codomyrmex/tests/unit/embodiment/test_embodiment_bases.py
+++ b/src/codomyrmex/tests/unit/embodiment/test_embodiment_bases.py
@@ -3,7 +3,6 @@
 import asyncio
 
 import pytest
-
 from codomyrmex.embodiment.actuators.base import (
     ActuatorCommand,
     ActuatorStatus,

--- a/src/codomyrmex/tests/unit/embodiment/test_transformation.py
+++ b/src/codomyrmex/tests/unit/embodiment/test_transformation.py
@@ -3,7 +3,6 @@
 import math
 
 import pytest
-
 from codomyrmex.embodiment.transformation.transformation import Transform3D, Vec3
 
 


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the `list_cloud_instances` function in `src/codomyrmex/cloud/mcp_tools.py` using `_stubs.Stub` to adhere to the zero-mock policy.
📊 **Coverage:** Successfully covers both the happy path (returning correctly mapped instances including fallback configurations) and the error scenario (handling an `API Error` exception).
✨ **Result:** Improved test coverage for cloud components ensuring reliable verification without external mock objects.

---
*PR created automatically by Jules for task [11979320580128781528](https://jules.google.com/task/11979320580128781528) started by @docxology*