### PR TITLE
🔒 fix shell injection vulnerability in OSProviderBase.execute_command

### DIFF
--- a/src/codomyrmex/operating_system/base.py
+++ b/src/codomyrmex/operating_system/base.py
@@ -8,6 +8,7 @@ that each platform-specific provider must implement.
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import time
 from abc import ABC, abstractmethod
@@ -248,9 +249,10 @@ class OSProviderBase(ABC):
         """
         start = time.time()
         try:
+            cmd_args = command if os.name == "nt" else shlex.split(command)
             result = subprocess.run(
-                command,
-                shell=True,
+                cmd_args,
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=timeout,


### PR DESCRIPTION
Fixes a critical command injection vulnerability by removing the `shell=True` argument from the `OSProviderBase.execute_command` method in `src/codomyrmex/operating_system/base.py`. This method acts as an endpoint for external users executing arbitrary commands via MCP tools, meaning `shell=True` was a major vulnerability. The solution replaces it with safe processing logic, converting commands to `shlex.split` arrays on POSIX systems while retaining raw string capabilities on Windows, both with `shell=False`.

---
*PR created automatically by Jules for task [17701893345744372733](https://jules.google.com/task/17701893345744372733) started by @docxology*