### PR TITLE
🔒 fix: remove shell=True in deployment hooks

### DIFF
--- a/src/codomyrmex/ci_cd_automation/deployment_orchestrator.py
+++ b/src/codomyrmex/ci_cd_automation/deployment_orchestrator.py
@@ -8,6 +8,7 @@ and release coordination capabilities.
 import importlib
 import json
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -562,9 +563,11 @@ class DeploymentOrchestrator:
                 env.update(deployment.environment.variables)
                 env["DEPLOYMENT_VERSION"] = deployment.version
 
+                cmd = hook if os.name == "nt" else shlex.split(hook)
+
                 result = subprocess.run(
-                    hook,
-                    shell=True,
+                    cmd,
+                    shell=False,
                     capture_output=True,
                     text=True,
                     cwd=os.getcwd(),

--- a/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator_comprehensive.py
+++ b/src/codomyrmex/tests/unit/ci_cd_automation/test_deployment_orchestrator_comprehensive.py
@@ -59,7 +59,7 @@ class TestDeploymentOrchestrator:
         """Test deployment with a failing pre-deploy hook."""
         orchestrator = DeploymentOrchestrator(config_file)
         env = orchestrator.environments["staging"]
-        env.pre_deploy_hooks = ["exit 1"]
+        env.pre_deploy_hooks = ["false"]
 
         deployment = orchestrator.create_deployment("fail-hook", "1.0", "staging", [])
         # We don't rollback if it's not a real failure during deployment itself


### PR DESCRIPTION
🎯 **What:** Replaced `shell=True` with `shell=False` in the execution of deployment hooks (`subprocess.run`). Used `shlex.split()` to parse the command string into a list on Unix-like systems, while preserving strings for Windows execution. Updated a comprehensive unit test to use 'false' instead of the shell built-in 'exit 1'.
⚠️ **Risk:** Executing hooks with `shell=True` allows for command injection if the hook definitions in the configuration are ever manipulated by a malicious actor.
🛡️ **Solution:** By setting `shell=False` and properly tokenizing the command arguments via `shlex.split()`, the system avoids invoking a shell interpreter, effectively neutralizing shell-based injection attacks while maintaining cross-platform compatibility.

---
*PR created automatically by Jules for task [5271895616005229632](https://jules.google.com/task/5271895616005229632) started by @docxology*