### PR TITLE
🧪 test: add cache_stats unit tests and fix in-memory write/delete stats recording

### DIFF
--- a/src/codomyrmex/cache/backends/in_memory.py
+++ b/src/codomyrmex/cache/backends/in_memory.py
@@ -58,6 +58,7 @@ class InMemoryCache(Cache):
         ttl = ttl or self.default_ttl
         self._cache[key] = (value, time.time(), ttl)
         self._stats.size = len(self._cache)
+        self._stats.record_write()
         return True
 
     def delete(self, key: str) -> bool:
@@ -65,6 +66,7 @@ class InMemoryCache(Cache):
         if key in self._cache:
             del self._cache[key]
             self._stats.size = len(self._cache)
+            self._stats.record_delete()
             return True
         return False
 

--- a/src/codomyrmex/tests/unit/cache/test_cache_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/cache/test_cache_mcp_tools.py
@@ -90,8 +90,55 @@ def test_cache_stats_returns_dict() -> None:
 
     stats = cache_stats(cache_name=_unique_cache())
     assert isinstance(stats, dict)
-    assert "hits" in stats
-    assert "misses" in stats
+
+    expected_keys = {
+        "hits",
+        "misses",
+        "total_requests",
+        "hit_rate",
+        "size",
+        "max_size",
+        "usage_percent",
+        "evictions",
+        "writes",
+        "deletes",
+    }
+    for key in expected_keys:
+        assert key in stats
+
+
+def test_cache_stats_writes_and_deletes() -> None:
+    """Writes, deletes, and size metrics are accurately updated in stats."""
+    from codomyrmex.cache.mcp_tools import cache_delete, cache_set, cache_stats
+
+    cache_name = _unique_cache()
+
+    # Initially empty
+    stats = cache_stats(cache_name=cache_name)
+    assert stats["writes"] == 0
+    assert stats["deletes"] == 0
+    assert stats["size"] == 0
+
+    # After a set
+    cache_set("k1", "v1", cache_name=cache_name)
+    stats = cache_stats(cache_name=cache_name)
+    assert stats["writes"] == 1
+    assert stats["deletes"] == 0
+    assert stats["size"] == 1
+
+    # After another set
+    cache_set("k2", "v2", cache_name=cache_name)
+    stats = cache_stats(cache_name=cache_name)
+    assert stats["writes"] == 2
+    assert stats["deletes"] == 0
+    assert stats["size"] == 2
+
+    # After a delete
+    cache_delete("k1", cache_name=cache_name)
+    stats = cache_stats(cache_name=cache_name)
+    assert stats["writes"] == 2
+    assert stats["deletes"] == 1
+    assert stats["size"] == 1
 
 
 def test_cache_stats_hit_rate_after_operations() -> None:


### PR DESCRIPTION
🎯 **What:** The `cache_stats` MCP tool was insufficiently tested. Its unit tests did not assert all required stats metric keys and it wasn't tested for reflecting cache insertions and deletions properly. Moreover, a bug existed in the `InMemoryCache` backend where writes and deletions were not being correctly recorded.
📊 **Coverage:** The test suite now asserts every expected dictionary key from `cache_stats`. A new test, `test_cache_stats_writes_and_deletes`, effectively tests setting and deleting values and confirms their reflection in stats. The source code implementation of `InMemoryCache` is updated to correctly call `self._stats.record_write()` and `self._stats.record_delete()`.
✨ **Result:** Improved cache operation reliability with complete cache statistics unit tests. The system now behaves accurately during set and delete operations.

---
*PR created automatically by Jules for task [197781945876163079](https://jules.google.com/task/197781945876163079) started by @docxology*