### PR TITLE
🧪 test: add unit tests for cache cli_commands

### DIFF
--- a/src/codomyrmex/tests/unit/cache/test_cache.py
+++ b/src/codomyrmex/tests/unit/cache/test_cache.py
@@ -1062,3 +1062,55 @@ class TestCacheInvalidationManager:
         mgr.get("a")
         s = mgr.stats()
         assert isinstance(s, dict)
+
+
+@pytest.mark.unit
+class TestCacheCLICommands:
+    """Tests for cache CLI commands."""
+
+    def test_cli_commands_structure(self):
+        """Test the structure of the returned CLI commands dictionary."""
+        from codomyrmex.cache import cli_commands
+
+        commands = cli_commands()
+
+        assert "backends" in commands
+        assert "stats" in commands
+
+        assert "help" in commands["backends"]
+        assert "handler" in commands["backends"]
+        assert callable(commands["backends"]["handler"])
+
+        assert "help" in commands["stats"]
+        assert "handler" in commands["stats"]
+        assert callable(commands["stats"]["handler"])
+
+    def test_cli_commands_backends_handler(self, capsys):
+        """Test the backends command handler output."""
+        from codomyrmex.cache import cli_commands
+
+        commands = cli_commands()
+        handler = commands["backends"]["handler"]
+
+        handler()
+        captured = capsys.readouterr()
+
+        assert "Cache Backends:" in captured.out
+        assert "in_memory" in captured.out
+        assert "file_based" in captured.out
+        assert "redis" in captured.out
+
+    def test_cli_commands_stats_handler(self, capsys):
+        """Test the stats command handler output."""
+        from codomyrmex.cache import cli_commands
+
+        commands = cli_commands()
+        handler = commands["stats"]["handler"]
+
+        handler()
+        captured = capsys.readouterr()
+
+        assert "Cache Statistics:" in captured.out
+        assert "Active caches :" in captured.out
+        assert "Total hits    :" in captured.out
+        assert "Total misses  :" in captured.out


### PR DESCRIPTION
🎯 **What:** The `cli_commands` function in `src/codomyrmex/cache/__init__.py` lacked test coverage.
📊 **Coverage:** Added the `TestCacheCLICommands` class which covers the structure of the returned commands (keys, help strings, callable handlers), as well as validating the standard output from both the `backends` and `stats` command handlers.
✨ **Result:** Increased cache module coverage and safely verified expected output using the `capsys` fixture.

---
*PR created automatically by Jules for task [1009354232114926209](https://jules.google.com/task/1009354232114926209) started by @docxology*