### PR TITLE
🧹 Remove commented out code in verify_fix.py

### DIFF
--- a/src/codomyrmex/coding/debugging/verify_fix.py
+++ b/src/codomyrmex/coding/debugging/verify_fix.py
@@ -22,9 +22,6 @@ from codomyrmex.logging_monitoring import get_logger
 if TYPE_CHECKING:
     from codomyrmex.coding.debugging.patch_generator import Patch
 
-# In a real scenario, this would import the Execution module
-# from codomyrmex.coding.execution import execute_code
-
 logger = get_logger(__name__)
 
 
@@ -100,8 +97,6 @@ class FixVerifier:
         self._apply_patch(original_source, patch)
 
         # 2. Execute patched code
-        # result = execute_code("python", patched_source, stdin=test_input)
-
         # Verification requires active code execution module — returns unverified result
         return VerificationResult(
             success=False,


### PR DESCRIPTION
🎯 **What:** Removed commented-out `execute_code` import and related dead code.
💡 **Why:** Improves code maintainability and readability by eliminating alternative/dead code blocks.
✅ **Verification:** Ran `uv run ruff check`, `uv run ruff format`, and `uv run pytest` to ensure no functionality is broken and formatting is preserved.
✨ **Result:** Cleaned up code without any behavior changes.

---
*PR created automatically by Jules for task [2433334907667717232](https://jules.google.com/task/2433334907667717232) started by @docxology*