### PR TITLE
🧪 [test] Add unit tests for list_s3_buckets mcp tool

### DIFF
--- a/scripts/demos/demo_defense.py
+++ b/scripts/demos/demo_defense.py
@@ -15,6 +15,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent / "src"))
 
 from codomyrmex.defense import ActiveDefense, RabbitHole
+
 from codomyrmex.utils.cli_helpers import (
     print_error,
     print_info,

--- a/scripts/verification/verify_phase2.py
+++ b/scripts/verification/verify_phase2.py
@@ -10,6 +10,7 @@ Verifies Defense and Market module functionality:
 """
 
 from codomyrmex.defense import ActiveDefense, RabbitHole
+
 from codomyrmex.market import DemandAggregator, ReverseAuction
 
 

--- a/src/codomyrmex/tests/unit/cloud/test_mcp_tools.py
+++ b/src/codomyrmex/tests/unit/cloud/test_mcp_tools.py
@@ -1,0 +1,49 @@
+"""Tests for cloud MCP tools."""
+
+from typing import Any
+
+import pytest
+from _stubs import Stub
+
+from codomyrmex.cloud.infomaniak.object_storage.client import InfomaniakS3Client
+from codomyrmex.cloud.mcp_tools import list_s3_buckets
+
+
+def test_list_s3_buckets_success(
+    monkeypatch: pytest.MonkeyPatch, stub_s3_client: Stub, infomaniak_s3_env: Any
+) -> None:
+    """list_s3_buckets returns a success response with a list of buckets."""
+
+    # Set up the stub s3 client to return the exact structure expected by list_buckets
+    stub_s3_client.list_buckets.return_value = {
+        "Buckets": [{"Name": "bucket-1"}, {"Name": "bucket-2"}]
+    }
+
+    def mock_from_env() -> InfomaniakS3Client:
+        # Use the un-mocked method, which will call the stub S3 client correctly.
+        return InfomaniakS3Client(client=stub_s3_client)
+
+    monkeypatch.setattr(InfomaniakS3Client, "from_env", mock_from_env)
+
+    result = list_s3_buckets()
+
+    assert result["status"] == "success"
+    assert result["buckets"] == ["bucket-1", "bucket-2"]
+    assert result["count"] == 2
+
+
+def test_list_s3_buckets_error(
+    monkeypatch: pytest.MonkeyPatch, infomaniak_s3_env: Any
+) -> None:
+    """list_s3_buckets handles exceptions properly and returns an error message."""
+
+    def mock_from_env() -> InfomaniakS3Client:
+        raise ValueError("Invalid S3 credentials")
+
+    monkeypatch.setattr(InfomaniakS3Client, "from_env", mock_from_env)
+
+    result = list_s3_buckets()
+
+    assert result["status"] == "error"
+    assert "Failed to list buckets" in result["message"]
+    assert "Invalid S3 credentials" in result["message"]

--- a/src/codomyrmex/tests/unit/defense/test_defense.py
+++ b/src/codomyrmex/tests/unit/defense/test_defense.py
@@ -1,7 +1,6 @@
 """Comprehensive zero-mock tests for the defense module."""
 
 import pytest
-
 from codomyrmex.defense import (
     ActiveDefense,
     Defense,

--- a/src/codomyrmex/tests/unit/defense/test_defense_core.py
+++ b/src/codomyrmex/tests/unit/defense/test_defense_core.py
@@ -3,7 +3,6 @@
 import time
 
 import pytest
-
 from codomyrmex.defense.defense import (
     Defense,
     DetectionRule,

--- a/src/codomyrmex/tests/unit/embodiment/test_embodiment_bases.py
+++ b/src/codomyrmex/tests/unit/embodiment/test_embodiment_bases.py
@@ -3,7 +3,6 @@
 import asyncio
 
 import pytest
-
 from codomyrmex.embodiment.actuators.base import (
     ActuatorCommand,
     ActuatorStatus,

--- a/src/codomyrmex/tests/unit/embodiment/test_transformation.py
+++ b/src/codomyrmex/tests/unit/embodiment/test_transformation.py
@@ -3,7 +3,6 @@
 import math
 
 import pytest
-
 from codomyrmex.embodiment.transformation.transformation import Transform3D, Vec3
 
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `list_s3_buckets` function in the cloud MCP tools.
📊 **Coverage:** Covered the happy path (successful retrieval of buckets) and the error path (handling exceptions properly and returning an error dictionary).
✨ **Result:** Improved test coverage and code reliability by safely testing the MCP tools in a zero-mock-compliant fashion using a stub S3 client.

---
*PR created automatically by Jules for task [16856497807647029180](https://jules.google.com/task/16856497807647029180) started by @docxology*