### PR TITLE
fix: 🔒 use safe schema for yaml loading

### DIFF
--- a/src/codomyrmex/pai_pm/server/routes/dispatch.ts
+++ b/src/codomyrmex/pai_pm/server/routes/dispatch.ts
@@ -21,6 +21,10 @@ const MISSIONS_DIR = join(PAI_DIR, "MEMORY", "STATE", "missions");
 
 const yaml = await import("js-yaml");
 
+function safeLoad(content: string) {
+    return yaml.load(content, { schema: yaml.JSON_SCHEMA });
+}
+
 const TIMEOUT_MS = 120_000;
 
 export async function handleDispatchRoutes(
@@ -157,7 +161,7 @@ export async function handleDispatchRoutes(
         });
         const projectFile = join(PROJECTS_DIR, projectId, "project.yaml");
         if (existsSync(projectFile)) {
-            const data = yaml.load(readFileSync(projectFile, "utf8")) as any;
+            const data = safeLoad(readFileSync(projectFile, "utf8")) as any;
             data.dispatch_context = globalThis._dispatchContexts.get(`project:${projectId}`);
             writeFileSync(projectFile, yaml.dump(data));
         }
@@ -180,7 +184,7 @@ export async function handleDispatchRoutes(
         });
         const missionsFile = join(MISSIONS_DIR, "missions.yaml");
         if (existsSync(missionsFile)) {
-            const missions = (yaml.load(readFileSync(missionsFile, "utf8")) as any[]) || [];
+            const missions = (safeLoad(readFileSync(missionsFile, "utf8")) as any[]) || [];
             const m = missions.find((x: any) => x.id === missionId);
             if (m) { m.dispatch_context = globalThis._dispatchContexts.get(`mission:${missionId}`); writeFileSync(missionsFile, yaml.dump(missions)); }
         }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an insecure `yaml.load()` call in `src/codomyrmex/pai_pm/server/routes/dispatch.ts` which could allow arbitrary code execution when parsing malicious YAML files (`project.yaml` and `missions.yaml`).
⚠️ **Risk:** If left unfixed, parsing untrusted YAML could lead to remote code execution (RCE).
🛡️ **Solution:** Implemented a `safeLoad` wrapper around `yaml.load` that explicitly uses `yaml.JSON_SCHEMA`, which restricts parsing to safe JSON types only, mitigating the risk of executing arbitrary code via YAML tags.

---
*PR created automatically by Jules for task [3809048130058059654](https://jules.google.com/task/3809048130058059654) started by @docxology*