### PR TITLE
fix: 🛡️ [CRITICAL] replace eval() with safe AST evaluation in orchestrator DAG

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,14 @@ Duplicate definitions across modules (e.g., repeating the `SecretType` definitio
 
 **Prevention:**
 Use descriptive suffixes or alternatives (e.g., changing `"password"` to `"password_type"`) for model or type definitions. Implement robust CI checks to enforce single-source-of-truth patterns rather than duplicating classes.
+
+## 2026-03-01 - Avoid eval() for untrusted code execution
+
+**Vulnerability:**
+The `orchestrator_run_dag` MCP tool in `src/codomyrmex/orchestrator/mcp_tools.py` accepted dynamic Python expressions in `fn_expr` and evaluated them using the Python built-in `eval()`. Although there was a weak guard preventing double underscores (`__`), bypassing `eval` restrictions is often possible. This allowed a critical vulnerability where arbitrary code could be executed.
+
+**Learning:**
+Never evaluate code expressions dynamically via `eval()`, even when provided an explicit namespace constraint. Restricting the globals and checking string patterns is insufficient to prevent complex injections.
+
+**Prevention:**
+Parse dynamic expressions safely using the `ast` module and evaluate the syntax tree manually in a tightly controlled custom parser (`_safe_eval`), mapping standard operations directly to operators without exposing the runtime.

--- a/scripts/demos/demo_defense.py
+++ b/scripts/demos/demo_defense.py
@@ -15,6 +15,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent / "src"))
 
 from codomyrmex.defense import ActiveDefense, RabbitHole
+
 from codomyrmex.utils.cli_helpers import (
     print_error,
     print_info,

--- a/scripts/generate_manuscript_figures.py
+++ b/scripts/generate_manuscript_figures.py
@@ -1767,8 +1767,13 @@ def fig_gate_score_3d() -> None:
 
     norm = plt.Normalize(0, 1)
     surf = ax1.plot_surface(
-        T, C, score_best, facecolors=plt.cm.YlOrRd(norm(score_best)),
-        alpha=0.92, linewidth=0, antialiased=True
+        T,
+        C,
+        score_best,
+        facecolors=plt.cm.YlOrRd(norm(score_best)),
+        alpha=0.92,
+        linewidth=0,
+        antialiased=True,
     )
 
     ax1.set_xlabel("Trust score", fontsize=9, labelpad=8)
@@ -1781,19 +1786,41 @@ def fig_gate_score_3d() -> None:
     ax2.set_facecolor("#F7F9FC")
     _pub_style(ax2)
 
-    for trust_val, ls, marker, color in [(0.2, "--", "v", "#D55E00"),
-                                          (0.5, "-.", "s", _OI["blue"]),
-                                          (0.9, "-", "o", _OI["green"])]:
+    for trust_val, ls, marker, color in [
+        (0.2, "--", "v", "#D55E00"),
+        (0.5, "-.", "s", _OI["blue"]),
+        (0.9, "-", "o", _OI["green"]),
+    ]:
         scores = w_trust * trust_val + w_complete * C[:, 0]
         total_score = 0.60 + scores  # budget=risk=1.0
-        ax2.plot(C[:, 0], total_score, label=f"trust={trust_val:.1f}",
-                 linestyle=ls, color=color, lw=2.2, marker=marker,
-                 markevery=10, markersize=5)
+        ax2.plot(
+            C[:, 0],
+            total_score,
+            label=f"trust={trust_val:.1f}",
+            linestyle=ls,
+            color=color,
+            lw=2.2,
+            marker=marker,
+            markevery=10,
+            markersize=5,
+        )
 
-    ax2.axhline(y=gate_exec, color="#0072B2", linestyle="--", lw=1.2,
-                alpha=0.7, label=f"EXECUTE (g≥{gate_exec})")
-    ax2.axhline(y=gate_hold, color="#D55E00", linestyle=":", lw=1.2,
-                alpha=0.7, label=f"HOLD (g≥{gate_hold})")
+    ax2.axhline(
+        y=gate_exec,
+        color="#0072B2",
+        linestyle="--",
+        lw=1.2,
+        alpha=0.7,
+        label=f"EXECUTE (g≥{gate_exec})",
+    )
+    ax2.axhline(
+        y=gate_hold,
+        color="#D55E00",
+        linestyle=":",
+        lw=1.2,
+        alpha=0.7,
+        label=f"HOLD (g≥{gate_hold})",
+    )
     ax2.fill_between(C[:, 0], 0.60, gate_hold, alpha=0.06, color="#D55E00")
     ax2.fill_between(C[:, 0], gate_hold, gate_exec, alpha=0.06, color=_OI["yellow"])
     ax2.fill_between(C[:, 0], gate_exec, 1.0, alpha=0.06, color=_OI["green"])
@@ -1819,30 +1846,54 @@ def fig_fep_correspondence() -> None:
     A tiled table with color-coded rows showing the correspondence.
     """
     rows = [
-        ("Generative model\np(o, s)", "PheromoneStore +\nConsequenceMemory",
-         "Field stores accumulated\nconsequence history",
-         _OI["blue"]),
-        ("Observations o", "Pheromone field:\nTraceField.sense()",
-         "Signal strengths at\n(tick, location, type)",
-         _OI["sky"]),
-        ("Hidden states s", "AgentTrustProfile:\ntrust_score, role",
-         "Latent competence\ninferred from outcomes",
-         _OI["orange"]),
-        ("Variational posterior\nq(s)", "RoleAdapter.infer_role()",
-         "Deterministic mapping\nfrom trust→role",
-         _OI["pink"]),
-        ("Expected Free Energy\nG(π)", "ActuationGate.evaluate()\ngate_score",
-         "Cost of acting with\ncurrent belief state",
-         _OI["vermil"]),
-        ("Policy π", "ActionProposal\n(action_type, target)",
-         "Proposed course of\naction for gate",
-         _OI["green"]),
-        ("Active inference\n(action selection)", "GateResult:\nEXECUTE/HOLD/REFUSE",
-         "Score-thresholded\nternary decision",
-         "#555555"),
-        ("Learning\n(parameter update)", "ConsequenceMemory.record()\ntrust_delta",
-         "Trust deltas as\nparameter updates",
-         _OI["pink"]),
+        (
+            "Generative model\np(o, s)",
+            "PheromoneStore +\nConsequenceMemory",
+            "Field stores accumulated\nconsequence history",
+            _OI["blue"],
+        ),
+        (
+            "Observations o",
+            "Pheromone field:\nTraceField.sense()",
+            "Signal strengths at\n(tick, location, type)",
+            _OI["sky"],
+        ),
+        (
+            "Hidden states s",
+            "AgentTrustProfile:\ntrust_score, role",
+            "Latent competence\ninferred from outcomes",
+            _OI["orange"],
+        ),
+        (
+            "Variational posterior\nq(s)",
+            "RoleAdapter.infer_role()",
+            "Deterministic mapping\nfrom trust→role",
+            _OI["pink"],
+        ),
+        (
+            "Expected Free Energy\nG(π)",
+            "ActuationGate.evaluate()\ngate_score",
+            "Cost of acting with\ncurrent belief state",
+            _OI["vermil"],
+        ),
+        (
+            "Policy π",
+            "ActionProposal\n(action_type, target)",
+            "Proposed course of\naction for gate",
+            _OI["green"],
+        ),
+        (
+            "Active inference\n(action selection)",
+            "GateResult:\nEXECUTE/HOLD/REFUSE",
+            "Score-thresholded\nternary decision",
+            "#555555",
+        ),
+        (
+            "Learning\n(parameter update)",
+            "ConsequenceMemory.record()\ntrust_delta",
+            "Trust deltas as\nparameter updates",
+            _OI["pink"],
+        ),
     ]
 
     fig, ax = plt.subplots(figsize=(10, 5.5))
@@ -1857,16 +1908,26 @@ def fig_fep_correspondence() -> None:
     table_h = n_rows * row_h + 0.3
 
     # Headers
-    headers = ["FEP component", "Colony Kernel\nsubsystem", "Formal\ncorrespondence", "Decay\nclass"]
+    headers = [
+        "FEP component",
+        "Colony Kernel\nsubsystem",
+        "Formal\ncorrespondence",
+        "Decay\nclass",
+    ]
     x_positions = [sum(col_widths[:i]) for i in range(len(col_widths))]
     start_x = (1 - table_w) / 2
     start_y = 0.92
 
     for i, (header, x_pos) in enumerate(zip(headers, x_positions, strict=False)):
         ax.text(
-            start_x + x_pos + col_widths[i] / 2, start_y,
-            header, ha="center", va="center", fontsize=8.5,
-            fontweight="bold", color="#1a1a1a",
+            start_x + x_pos + col_widths[i] / 2,
+            start_y,
+            header,
+            ha="center",
+            va="center",
+            fontsize=8.5,
+            fontweight="bold",
+            color="#1a1a1a",
         )
 
     # Rows
@@ -1874,21 +1935,40 @@ def fig_fep_correspondence() -> None:
         y = start_y - 0.08 - (r + 1) * row_h
         # Row background
         bg_color = "#EBF0F5" if r % 2 == 0 else "#F7F9FC"
-        ax.add_patch(plt.Rectangle(
-            (start_x, y), table_w, row_h,
-            facecolor=bg_color, edgecolor="none", alpha=0.6, zorder=0,
-        ))
+        ax.add_patch(
+            plt.Rectangle(
+                (start_x, y),
+                table_w,
+                row_h,
+                facecolor=bg_color,
+                edgecolor="none",
+                alpha=0.6,
+                zorder=0,
+            )
+        )
         # Color stripe
-        ax.add_patch(plt.Rectangle(
-            (start_x, y), 0.04, row_h,
-            facecolor=color, edgecolor="none", alpha=0.9, zorder=1,
-        ))
+        ax.add_patch(
+            plt.Rectangle(
+                (start_x, y),
+                0.04,
+                row_h,
+                facecolor=color,
+                edgecolor="none",
+                alpha=0.9,
+                zorder=1,
+            )
+        )
         # Cells
         texts = [fep, kernel, formal, ""]
-        for j, (txt, x_pos, cw) in enumerate(zip(texts, x_positions, col_widths, strict=False)):
+        for j, (txt, x_pos, cw) in enumerate(
+            zip(texts, x_positions, col_widths, strict=False)
+        ):
             ax.text(
-                start_x + x_pos + cw / 2, y + row_h / 2,
-                txt, ha="center", va="center",
+                start_x + x_pos + cw / 2,
+                y + row_h / 2,
+                txt,
+                ha="center",
+                va="center",
                 fontsize=7.0 if j < 3 else 6.5,
                 color="#1a1a1a",
                 linespacing=1.2,
@@ -1897,7 +1977,9 @@ def fig_fep_correspondence() -> None:
     ax.set_title(
         "Free Energy Principle — Colony Kernel correspondence\n"
         "Each FEP component maps to a deterministic colony subsystem",
-        fontsize=11, pad=6, color="#1a1a1a",
+        fontsize=11,
+        pad=6,
+        color="#1a1a1a",
     )
     _add_provenance_note(fig)
     fig.tight_layout(pad=0.4, rect=(0, 0.035, 1, 1))
@@ -1913,16 +1995,29 @@ def fig_formula_comparison() -> None:
     Used by 90_appendix_design_rationale.md §dr-gate-formula.
     Creates a grouped bar chart for visual comparison.
     """
-    approaches = ["Weighted\nadditive", "Multiplicative", "Learned\nclassifier", "Rule\nsystem"]
-    criteria = ["Auditability", "Zero-shot\nvalidity", "Recovery\nsupport",
-                "Calibration\ncost", "Interpretability", "Safety\nguarantees"]
+    approaches = [
+        "Weighted\nadditive",
+        "Multiplicative",
+        "Learned\nclassifier",
+        "Rule\nsystem",
+    ]
+    criteria = [
+        "Auditability",
+        "Zero-shot\nvalidity",
+        "Recovery\nsupport",
+        "Calibration\ncost",
+        "Interpretability",
+        "Safety\nguarantees",
+    ]
     # Scores: 5 = best, 1 = worst
-    scores = np.array([
-        [5, 5, 4, 5, 5, 4],   # Weighted additive
-        [3, 3, 2, 5, 3, 3],   # Multiplicative
-        [1, 1, 3, 1, 1, 2],   # Learned classifier
-        [4, 4, 1, 5, 4, 3],   # Rule system
-    ])
+    scores = np.array(
+        [
+            [5, 5, 4, 5, 5, 4],  # Weighted additive
+            [3, 3, 2, 5, 3, 3],  # Multiplicative
+            [1, 1, 3, 1, 1, 2],  # Learned classifier
+            [4, 4, 1, 5, 4, 3],  # Rule system
+        ]
+    )
 
     fig, ax = plt.subplots(figsize=(10, 5.5))
     ax.set_facecolor("#F7F9FC")
@@ -1938,16 +2033,28 @@ def fig_formula_comparison() -> None:
     for i, (approach, color) in enumerate(zip(approaches, colors, strict=False)):
         offset = (i - n_approaches / 2 + 0.5) * bar_width
         bars = ax.bar(
-            x + offset, scores[i], bar_width,
+            x + offset,
+            scores[i],
+            bar_width,
             label=approach.replace("\n", " "),
-            color=color, alpha=0.85, edgecolor="white", linewidth=1.2,
+            color=color,
+            alpha=0.85,
+            edgecolor="white",
+            linewidth=1.2,
             zorder=3,
         )
         # Annotate bars
         for bar, score in zip(bars, scores[i], strict=False):
-            ax.text(bar.get_x() + bar.get_width() / 2, score + 0.08,
-                    str(score), ha="center", va="bottom", fontsize=8,
-                    fontweight="bold", color=color)
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                score + 0.08,
+                str(score),
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                fontweight="bold",
+                color=color,
+            )
 
     ax.set_xticks(x)
     ax.set_xticklabels(criteria, fontsize=8)
@@ -1957,16 +2064,26 @@ def fig_formula_comparison() -> None:
     ax.set_title(
         "Gate formula approach comparison across 6 criteria\n"
         "Weighted additive achieves the best combination of auditability, safety, and flexibility",
-        fontsize=11, pad=10, color="#1a1a1a",
+        fontsize=11,
+        pad=10,
+        color="#1a1a1a",
     )
 
     # Highlight additive column
     for i in range(n_criteria):
         max_score = scores[:, i].max()
         if scores[0, i] == max_score:
-            ax.text(x[i], 5.85, "← best", ha="center", va="bottom",
-                    fontsize=7.5, color=_OI["vermil"], fontweight="bold",
-                    style="italic")
+            ax.text(
+                x[i],
+                5.85,
+                "← best",
+                ha="center",
+                va="bottom",
+                fontsize=7.5,
+                color=_OI["vermil"],
+                fontweight="bold",
+                style="italic",
+            )
 
     _add_provenance_note(fig)
     fig.tight_layout(pad=0.4, rect=(0, 0.035, 1, 1))

--- a/scripts/verification/verify_phase2.py
+++ b/scripts/verification/verify_phase2.py
@@ -10,6 +10,7 @@ Verifies Defense and Market module functionality:
 """
 
 from codomyrmex.defense import ActiveDefense, RabbitHole
+
 from codomyrmex.market import DemandAggregator, ReverseAuction
 
 

--- a/src/codomyrmex/colony_kernel/__init__.py
+++ b/src/codomyrmex/colony_kernel/__init__.py
@@ -95,4 +95,3 @@ __all__ = [
     "load_roles_yaml",
     "make_trace_key",
 ]
-

--- a/src/codomyrmex/colony_kernel/actuation_gate.py
+++ b/src/codomyrmex/colony_kernel/actuation_gate.py
@@ -446,7 +446,9 @@ class ActuationGate:
             if trust_ok < 1.0:
                 required.append("increase_trust_score_via_accepted_proposals")
             if risk_ok < 1.0:
-                required.append("wait_for_risk_pheromone_to_decay_or_address_root_cause")
+                required.append(
+                    "wait_for_risk_pheromone_to_decay_or_address_root_cause"
+                )
             if findings:
                 required.append("resolve_falsification_findings")
             if not required:

--- a/src/codomyrmex/colony_kernel/config_loader.py
+++ b/src/codomyrmex/colony_kernel/config_loader.py
@@ -257,7 +257,9 @@ def default_gate_config_from_yaml() -> dict[str, Any]:
 
     # Validate gate score weights sum constraints
     if gate_section:
-        execute = gate_section.get("execute_threshold", gate_section.get("score_execute"))
+        execute = gate_section.get(
+            "execute_threshold", gate_section.get("score_execute")
+        )
         hold = gate_section.get("hold_threshold", gate_section.get("score_hold"))
         if execute is not None and hold is not None:
             try:

--- a/src/codomyrmex/colony_kernel/invariants.py
+++ b/src/codomyrmex/colony_kernel/invariants.py
@@ -58,9 +58,9 @@ def check_gate_weights_sum_to_one(
 
     Example::
 
-        assert check_gate_weights_sum_to_one()                     # canonical
+        assert check_gate_weights_sum_to_one()  # canonical
         assert check_gate_weights_sum_to_one([0.25, 0.25, 0.25, 0.25])  # custom
-        assert not check_gate_weights_sum_to_one([0.30, 0.30, 0.30])    # sum != 1
+        assert not check_gate_weights_sum_to_one([0.30, 0.30, 0.30])  # sum != 1
     """
     if weights is None:
         weights = _GATE_WEIGHTS
@@ -93,6 +93,7 @@ def check_trust_score_in_range(
     Example::
 
         from codomyrmex.colony_kernel.models import AgentTrustProfile, AgentRole
+
         p = AgentTrustProfile(agent_id="a", trust_score=0.5)
         assert check_trust_score_in_range([p])
 
@@ -139,7 +140,7 @@ def check_pheromone_strength_bounds(
     Example::
 
         assert check_pheromone_strength_bounds([0.0, 1.5, 999.9])
-        assert not check_pheromone_strength_bounds([-0.1])         # below floor
+        assert not check_pheromone_strength_bounds([-0.1])  # below floor
         assert not check_pheromone_strength_bounds([1_000_001.0])  # above ceiling
     """
     if strengths is None:
@@ -187,10 +188,10 @@ def check_role_ladder_monotonic(
 
     Example::
 
-        assert check_role_ladder_monotonic()              # canonical thresholds
+        assert check_role_ladder_monotonic()  # canonical thresholds
         assert check_role_ladder_monotonic([0.1, 0.3, 0.6, 0.9])
-        assert not check_role_ladder_monotonic([0.3, 0.3, 0.5])   # tie
-        assert not check_role_ladder_monotonic([0.5, 0.3, 0.8])   # decrease
+        assert not check_role_ladder_monotonic([0.3, 0.3, 0.5])  # tie
+        assert not check_role_ladder_monotonic([0.5, 0.3, 0.8])  # decrease
     """
     if thresholds is None:
         thresholds = _ROLE_LADDER_THRESHOLDS

--- a/src/codomyrmex/colony_kernel/kernel.py
+++ b/src/codomyrmex/colony_kernel/kernel.py
@@ -218,9 +218,7 @@ class ColonyKernel:
                     evidence={
                         "proposal_id": proposal.proposal_id,
                         "finding_count": len(risk_findings),
-                        "max_severity": max(
-                            f.severity.value for f in risk_findings
-                        ),
+                        "max_severity": max(f.severity.value for f in risk_findings),
                     },
                 )
                 self.pheromone_store.deposit(

--- a/src/codomyrmex/colony_kernel/pheromone_store.py
+++ b/src/codomyrmex/colony_kernel/pheromone_store.py
@@ -179,6 +179,7 @@ class PheromoneStore:
         """
         if signal.strength > _MAX_DEPOSIT_STRENGTH:
             import warnings as _warnings
+
             _warnings.warn(
                 f"PheromoneStore.deposit_signal: strength {signal.strength!r} exceeds "
                 f"maximum allowed value {_MAX_DEPOSIT_STRENGTH}; clamping to "
@@ -186,6 +187,7 @@ class PheromoneStore:
                 stacklevel=2,
             )
             import dataclasses as _dc
+
             signal = _dc.replace(signal, strength=_MAX_DEPOSIT_STRENGTH)
 
         key = _make_key(signal.signal_type, signal.location)

--- a/src/codomyrmex/colony_kernel/resource_ledger.py
+++ b/src/codomyrmex/colony_kernel/resource_ledger.py
@@ -378,6 +378,7 @@ class ThreadSafeResourceLedger:
     Example::
 
         from threading import Lock
+
         ledger = ThreadSafeResourceLedger(ResourceLedger(budget=budget))
         ok, reason = ledger.check_and_consume(cost, agent_id="worker-1")
 
@@ -387,6 +388,7 @@ class ThreadSafeResourceLedger:
 
     def __init__(self, ledger: ResourceLedger) -> None:
         import threading
+
         self._ledger = ledger
         self._lock = threading.Lock()
 

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -119,7 +119,9 @@ def orchestrator_run_dag(
         Aggregated result dict with per-task outputs, success/error counts.
     """
     try:
+        import ast
         import importlib
+        import operator
 
         from codomyrmex.orchestrator.swarm_topology import (
             SwarmTopology,
@@ -150,7 +152,48 @@ def orchestrator_run_dag(
                     "abs": abs,
                     "round": round,
                 }
-                return lambda *_a, **_kw: eval(expr, {"__builtins__": {}}, safe_locals)
+
+                _MATH_OPS = {
+                    ast.Add: operator.add,
+                    ast.Sub: operator.sub,
+                    ast.Mult: operator.mul,
+                    ast.Div: operator.truediv,
+                    ast.USub: operator.neg,
+                    ast.UAdd: operator.pos,
+                }
+
+                def _safe_eval(node: ast.AST):
+                    if isinstance(node, ast.Expression):
+                        return _safe_eval(node.body)
+                    if isinstance(node, ast.Constant):
+                        return node.value
+                    if isinstance(node, ast.List):
+                        return [_safe_eval(elt) for elt in node.elts]
+                    if isinstance(node, ast.Tuple):
+                        return tuple(_safe_eval(elt) for elt in node.elts)
+                    if isinstance(node, ast.Set):
+                        return {_safe_eval(elt) for elt in node.elts}
+                    if isinstance(node, ast.Dict):
+                        return {_safe_eval(k): _safe_eval(v) for k, v in zip(node.keys, node.values)}
+                    if isinstance(node, ast.Name):
+                        if node.id in safe_locals:
+                            return safe_locals[node.id]
+                        raise ValueError(f"Disallowed name: {node.id}")
+                    if isinstance(node, ast.Call):
+                        func = _safe_eval(node.func)
+                        args = [_safe_eval(arg) for arg in node.args]
+                        kwargs = {kw.arg: _safe_eval(kw.value) for kw in node.keywords if kw.arg}
+                        return func(*args, **kwargs)
+                    if isinstance(node, ast.BinOp) and type(node.op) in _MATH_OPS:
+                        return _MATH_OPS[type(node.op)](
+                            _safe_eval(node.left),
+                            _safe_eval(node.right),
+                        )
+                    if isinstance(node, ast.UnaryOp) and type(node.op) in _MATH_OPS:
+                        return _MATH_OPS[type(node.op)](_safe_eval(node.operand))
+                    raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+                return lambda *_a, **_kw: _safe_eval(ast.parse(expr, mode="eval"))
             # Default: identity (return args as-is)
             return lambda *a, **kw: {"args": a, "kwargs": kw}
 

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -174,7 +174,10 @@ def orchestrator_run_dag(
                     if isinstance(node, ast.Set):
                         return {_safe_eval(elt) for elt in node.elts}
                     if isinstance(node, ast.Dict):
-                        return {_safe_eval(k): _safe_eval(v) for k, v in zip(node.keys, node.values)}
+                        return {
+                            _safe_eval(k): _safe_eval(v)
+                            for k, v in zip(node.keys, node.values, strict=False)
+                        }
                     if isinstance(node, ast.Name):
                         if node.id in safe_locals:
                             return safe_locals[node.id]
@@ -182,7 +185,11 @@ def orchestrator_run_dag(
                     if isinstance(node, ast.Call):
                         func = _safe_eval(node.func)
                         args = [_safe_eval(arg) for arg in node.args]
-                        kwargs = {kw.arg: _safe_eval(kw.value) for kw in node.keywords if kw.arg}
+                        kwargs = {
+                            kw.arg: _safe_eval(kw.value)
+                            for kw in node.keywords
+                            if kw.arg
+                        }
                         return func(*args, **kwargs)
                     if isinstance(node, ast.BinOp) and type(node.op) in _MATH_OPS:
                         return _MATH_OPS[type(node.op)](

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -194,10 +194,10 @@ def orchestrator_run_dag(
                     if isinstance(node, ast.BinOp) and type(node.op) in _MATH_OPS:
                         return _MATH_OPS[type(node.op)](
                             _safe_eval(node.left),
-                            _safe_eval(node.right),
+                            _safe_eval(node.right),  # type: ignore
                         )
                     if isinstance(node, ast.UnaryOp) and type(node.op) in _MATH_OPS:
-                        return _MATH_OPS[type(node.op)](_safe_eval(node.operand))
+                        return _MATH_OPS[type(node.op)](_safe_eval(node.operand))  # type: ignore
                     raise ValueError(f"Unsupported expression: {ast.dump(node)}")
 
                 return lambda *_a, **_kw: _safe_eval(ast.parse(expr, mode="eval"))

--- a/src/codomyrmex/tests/unit/colony_kernel/test_manuscript_consistency.py
+++ b/src/codomyrmex/tests/unit/colony_kernel/test_manuscript_consistency.py
@@ -985,14 +985,30 @@ def test_crossref_labels_are_unique_referenced_and_resolved() -> None:
     # sections that are self-explanatory in context — not every equation
     # needs an explicit prose cross-reference.
     ALLOWED_UNREFERENCED = {
-        "eq:ai-likelihood", "eq:ai-observations", "eq:ai-posterior",
-        "eq:ai-prior", "eq:ai-states", "eq:efe-approximation",
-        "eq:expected-fe", "eq:expected-fe-intrinsic", "eq:variational-fe",
-        "tbl:ai-gate-mapping", "eq:theory-gate-score-detail",
-        "eq:gate-entropy", "eq:max-score-by-tier", "eq:min-execute",
-        "eq:corollary5", "eq:all-stress", "eq:cascaded-stress",
-        "eq:failure-cascade", "eq:ensemble-detection", "eq:f1", "eq:f2",
-        "eq:f3", "tbl:override-interactions", "tbl:trust-penalty-cascade",
+        "eq:ai-likelihood",
+        "eq:ai-observations",
+        "eq:ai-posterior",
+        "eq:ai-prior",
+        "eq:ai-states",
+        "eq:efe-approximation",
+        "eq:expected-fe",
+        "eq:expected-fe-intrinsic",
+        "eq:variational-fe",
+        "tbl:ai-gate-mapping",
+        "eq:theory-gate-score-detail",
+        "eq:gate-entropy",
+        "eq:max-score-by-tier",
+        "eq:min-execute",
+        "eq:corollary5",
+        "eq:all-stress",
+        "eq:cascaded-stress",
+        "eq:failure-cascade",
+        "eq:ensemble-detection",
+        "eq:f1",
+        "eq:f2",
+        "eq:f3",
+        "tbl:override-interactions",
+        "tbl:trust-penalty-cascade",
     }
     truly_unreferenced = sorted(
         l for l in unreferenced if l not in ALLOWED_UNREFERENCED

--- a/src/codomyrmex/tests/unit/colony_kernel/test_property_stress_integration.py
+++ b/src/codomyrmex/tests/unit/colony_kernel/test_property_stress_integration.py
@@ -92,7 +92,9 @@ def _good_proposal(
     )
 
 
-def _gate_with_no_pressure(trust_score: float) -> tuple[ActuationGate, AgentTrustProfile]:
+def _gate_with_no_pressure(
+    trust_score: float,
+) -> tuple[ActuationGate, AgentTrustProfile]:
     """Return a fresh gate + profile with the given trust score."""
     field = TraceField(StigmergyConfig())
     gate = ActuationGate(pheromone_store=field, resource_ledger=_UnlimitedLedger())
@@ -106,7 +108,9 @@ def _gate_with_no_pressure(trust_score: float) -> tuple[ActuationGate, AgentTrus
     return gate, profile
 
 
-def _gate_with_risk(pressure: float, target: str = "codomyrmex.some.module") -> ActuationGate:
+def _gate_with_risk(
+    pressure: float, target: str = "codomyrmex.some.module"
+) -> ActuationGate:
     """Return a gate with a RISK signal pre-loaded at *target* with *pressure*."""
     field = TraceField(StigmergyConfig(max_strength=200.0))
     key = f"{target}:{SignalType.RISK.value}"
@@ -273,9 +277,12 @@ class TestPropertyResourceCostArithmetic:
     @settings(max_examples=80, deadline=1000)
     def test_resource_cost_add_commutativity(
         self,
-        a_llm: int, b_llm: int,
-        a_runtime: float, b_runtime: float,
-        a_risk: float, b_risk: float,
+        a_llm: int,
+        b_llm: int,
+        a_runtime: float,
+        b_runtime: float,
+        a_risk: float,
+        b_risk: float,
     ) -> None:
         """a + b == b + a for llm_calls and runtime_seconds (risk saturates at 1.0)."""
         a = ResourceCost(llm_calls=a_llm, runtime_seconds=a_runtime, risk_level=a_risk)
@@ -307,7 +314,9 @@ class TestPropertyResourceCostArithmetic:
         abc_right = a + (b + c)
 
         assert abc_left.llm_calls == abc_right.llm_calls
-        assert abc_left.runtime_seconds == pytest.approx(abc_right.runtime_seconds, abs=1e-9)
+        assert abc_left.runtime_seconds == pytest.approx(
+            abc_right.runtime_seconds, abs=1e-9
+        )
 
     @given(llm=st.integers(min_value=0, max_value=100))
     @settings(max_examples=40, deadline=1000)
@@ -388,7 +397,9 @@ class TestGateExtremeRiskPressure:
             total_proposals=20,
             accepted_proposals=18,
         )
-        result = gate.evaluate(_good_proposal(agent_id="risk-sweep-agent", target=self._TARGET), profile)
+        result = gate.evaluate(
+            _good_proposal(agent_id="risk-sweep-agent", target=self._TARGET), profile
+        )
         return result.decision
 
     def test_zero_risk_pressure_executes(self) -> None:
@@ -413,7 +424,8 @@ class TestGateExtremeRiskPressure:
             accepted_proposals=3,
         )
         result = gate.evaluate(
-            _good_proposal(agent_id="med-risk-medium-trust", target=self._TARGET), profile
+            _good_proposal(agent_id="med-risk-medium-trust", target=self._TARGET),
+            profile,
         )
         # score = 0.30 + 0.5*0.30 + 0.5*0.25 + 0.15 = 0.30+0.15+0.125+0.15 = 0.725 < 0.75
         assert result.decision in {GateDecision.HOLD, GateDecision.EXECUTE}
@@ -594,7 +606,9 @@ class TestKernelThousandProposals:
                 target=f"codomyrmex.stress.module_{i % 10}",
                 rationale=f"Stress test proposal #{i} with full rationale text.",
                 expected_outcome=f"All tests pass after stress patch #{i}.",
-                budget_estimate=ResourceCost(llm_calls=1, runtime_seconds=1.0, risk_level=0.05),
+                budget_estimate=ResourceCost(
+                    llm_calls=1, runtime_seconds=1.0, risk_level=0.05
+                ),
                 rollback_plan="git revert HEAD",
                 evidence={"stress_run": i},
             )
@@ -646,7 +660,9 @@ class TestActuationGateExtremeFindings:
         gate, profile = self._gate_and_profile()
         proposal = _good_proposal(agent_id="findings-agent")
         findings = [self._finding(FalsificationSeverity.LOW) for _ in range(50)]
-        result = gate.evaluate(proposal, profile, findings=findings, budget_approved=True)
+        result = gate.evaluate(
+            proposal, profile, findings=findings, budget_approved=True
+        )
         assert isinstance(result.decision, GateDecision)
         assert 0.0 <= result.gate_score <= 1.0
 
@@ -659,7 +675,9 @@ class TestActuationGateExtremeFindings:
             self._finding(FalsificationSeverity.HIGH),
             self._finding(FalsificationSeverity.CRITICAL),
         ]
-        result = gate.evaluate(proposal, profile, findings=findings, budget_approved=True)
+        result = gate.evaluate(
+            proposal, profile, findings=findings, budget_approved=True
+        )
         assert isinstance(result.decision, GateDecision)
         assert 0.0 <= result.gate_score <= 1.0
 
@@ -667,7 +685,9 @@ class TestActuationGateExtremeFindings:
         """A CRITICAL finding contributes weight 1.0 and must reduce gate_score vs clean."""
         gate_clean, profile = self._gate_and_profile()
         proposal = _good_proposal(agent_id="findings-agent")
-        clean_result = gate_clean.evaluate(proposal, profile, findings=[], budget_approved=True)
+        clean_result = gate_clean.evaluate(
+            proposal, profile, findings=[], budget_approved=True
+        )
 
         gate_critical, profile2 = self._gate_and_profile()
         proposal2 = _good_proposal(agent_id="findings-agent")
@@ -1029,7 +1049,9 @@ class TestAllSignalTypesCanBeSensed:
         )
         store.deposit_signal(sig)
         sensed = store.sense(location, sig_type)
-        assert sensed > 0.0, f"Expected positive sense for {sig_type.value}; got {sensed}"
+        assert sensed > 0.0, (
+            f"Expected positive sense for {sig_type.value}; got {sensed}"
+        )
 
     @pytest.mark.parametrize("sig_type", list(SignalType))
     def test_sense_absent_signal_returns_zero(self, sig_type: SignalType) -> None:
@@ -1196,7 +1218,9 @@ class TestRoleAdapterThreeProposalsAllFailed:
 
         profile = AgentTrustProfile(agent_id="fail-trust-agent", trust_score=0.1)
         for _ in range(3):
-            delta = _TRUST_DELTA_FAIL + _TRUST_DELTA_REPAIR  # tests_passed=False, repair_needed=True
+            delta = (
+                _TRUST_DELTA_FAIL + _TRUST_DELTA_REPAIR
+            )  # tests_passed=False, repair_needed=True
             profile.apply_delta(delta)
         # Trust can only go down from failures
         assert profile.trust_score <= 0.1
@@ -1213,7 +1237,9 @@ class TestMakeTraceKeyAllSignalTypes:
     def test_all_signal_type_keys_distinct_at_same_location(self) -> None:
         location = "codomyrmex.key.integration"
         keys = [make_trace_key(location, st) for st in SignalType]
-        assert len(keys) == len(set(keys)), "Some SignalType keys collided at the same location"
+        assert len(keys) == len(set(keys)), (
+            "Some SignalType keys collided at the same location"
+        )
 
     def test_same_signal_type_different_locations_distinct(self) -> None:
         locations = [f"codomyrmex.module_{i}" for i in range(10)]

--- a/src/codomyrmex/tests/unit/defense/test_defense.py
+++ b/src/codomyrmex/tests/unit/defense/test_defense.py
@@ -1,7 +1,6 @@
 """Comprehensive zero-mock tests for the defense module."""
 
 import pytest
-
 from codomyrmex.defense import (
     ActiveDefense,
     Defense,

--- a/src/codomyrmex/tests/unit/defense/test_defense_core.py
+++ b/src/codomyrmex/tests/unit/defense/test_defense_core.py
@@ -3,7 +3,6 @@
 import time
 
 import pytest
-
 from codomyrmex.defense.defense import (
     Defense,
     DetectionRule,

--- a/src/codomyrmex/tests/unit/embodiment/test_embodiment_bases.py
+++ b/src/codomyrmex/tests/unit/embodiment/test_embodiment_bases.py
@@ -3,7 +3,6 @@
 import asyncio
 
 import pytest
-
 from codomyrmex.embodiment.actuators.base import (
     ActuatorCommand,
     ActuatorStatus,

--- a/src/codomyrmex/tests/unit/embodiment/test_transformation.py
+++ b/src/codomyrmex/tests/unit/embodiment/test_transformation.py
@@ -3,7 +3,6 @@
 import math
 
 import pytest
-
 from codomyrmex.embodiment.transformation.transformation import Transform3D, Vec3
 
 


### PR DESCRIPTION
**What:**
The `orchestrator_run_dag` MCP tool in `src/codomyrmex/orchestrator/mcp_tools.py` accepted dynamic Python expressions in `fn_expr` and executed them using the unsafe built-in `eval()` function.

**Risk:**
Remote Code Execution (RCE). An attacker or malicious AI agent providing a crafted `fn_expr` could bypass the weak `__` filter to execute arbitrary Python code, escaping the intended task limitations.

**Solution:**
Replaced `eval()` with a strict AST-based parsing function (`_safe_eval`). This parser safely resolves safe primitives (constants, lists, dicts) and whitelisted basic function calls (like `min`, `max`, `sum`), completely removing the ability to execute unvetted arbitrary logic while preserving necessary functionality. Evaluated via `ast.parse` in `mode="eval"`.

Also updated the Sentinel `.jules/sentinel.md` journal with this critical learning.

---
*PR created automatically by Jules for task [14558845627157616167](https://jules.google.com/task/14558845627157616167) started by @docxology*