### PR TITLE
fix: 🛡️ [CRITICAL] Replace eval with safe AST parser in orchestrator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@ Duplicate definitions across modules (e.g., repeating the `SecretType` definitio
 
 **Prevention:**
 Use descriptive suffixes or alternatives (e.g., changing `"password"` to `"password_type"`) for model or type definitions. Implement robust CI checks to enforce single-source-of-truth patterns rather than duplicating classes.
+
+## 2026-07-09 - Fix Critical eval() Vulnerability in Orchestrator MCP Tools
+**Vulnerability:** The orchestrator_run_dag tool used eval() to execute user-provided expressions for task execution, enabling code injection.
+**Learning:** Using eval() with user input is a critical security risk, even when restricting __builtins__ and locals, as it can often be bypassed.
+**Prevention:** Always use safe AST-based parsers (e.g., ast.parse combined with a strict recursive evaluator) to evaluate user-provided expressions without executing arbitrary code.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,8 +11,3 @@ Duplicate definitions across modules (e.g., repeating the `SecretType` definitio
 
 **Prevention:**
 Use descriptive suffixes or alternatives (e.g., changing `"password"` to `"password_type"`) for model or type definitions. Implement robust CI checks to enforce single-source-of-truth patterns rather than duplicating classes.
-
-## 2026-07-09 - Fix Critical eval() Vulnerability in Orchestrator MCP Tools
-**Vulnerability:** The orchestrator_run_dag tool used eval() to execute user-provided expressions for task execution, enabling code injection.
-**Learning:** Using eval() with user input is a critical security risk, even when restricting __builtins__ and locals, as it can often be bypassed.
-**Prevention:** Always use safe AST-based parsers (e.g., ast.parse combined with a strict recursive evaluator) to evaluate user-provided expressions without executing arbitrary code.

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -119,16 +119,15 @@ def orchestrator_run_dag(
         Aggregated result dict with per-task outputs, success/error counts.
     """
     try:
+        import ast
         import importlib
+        import operator
 
         from codomyrmex.orchestrator.swarm_topology import (
             SwarmTopology,
             TaskSpec,
             TopologyMode,
         )
-
-        import ast
-        import operator
 
         _MATH_OPS = {
             ast.Add: operator.add,
@@ -143,7 +142,6 @@ def orchestrator_run_dag(
         }
 
         def _safe_eval(node: ast.AST, safe_locals: dict):
-            """Recursively evaluate an AST node containing only safe operations."""
             if isinstance(node, ast.Expression):
                 return _safe_eval(node.body, safe_locals)
             if isinstance(node, ast.Constant):

--- a/src/codomyrmex/orchestrator/mcp_tools.py
+++ b/src/codomyrmex/orchestrator/mcp_tools.py
@@ -127,6 +127,47 @@ def orchestrator_run_dag(
             TopologyMode,
         )
 
+        import ast
+        import operator
+
+        _MATH_OPS = {
+            ast.Add: operator.add,
+            ast.Sub: operator.sub,
+            ast.Mult: operator.mul,
+            ast.Div: operator.truediv,
+            ast.FloorDiv: operator.floordiv,
+            ast.Mod: operator.mod,
+            ast.Pow: operator.pow,
+            ast.USub: operator.neg,
+            ast.UAdd: operator.pos,
+        }
+
+        def _safe_eval(node: ast.AST, safe_locals: dict):
+            """Recursively evaluate an AST node containing only safe operations."""
+            if isinstance(node, ast.Expression):
+                return _safe_eval(node.body, safe_locals)
+            if isinstance(node, ast.Constant):
+                return node.value
+            if isinstance(node, ast.List):
+                return [_safe_eval(elt, safe_locals) for elt in node.elts]
+            if isinstance(node, ast.Tuple):
+                return tuple(_safe_eval(elt, safe_locals) for elt in node.elts)
+            if isinstance(node, ast.BinOp) and type(node.op) in _MATH_OPS:
+                return _MATH_OPS[type(node.op)](
+                    _safe_eval(node.left, safe_locals),
+                    _safe_eval(node.right, safe_locals),
+                )
+            if isinstance(node, ast.UnaryOp) and type(node.op) in _MATH_OPS:
+                return _MATH_OPS[type(node.op)](_safe_eval(node.operand, safe_locals))
+            if isinstance(node, ast.Call):
+                if not isinstance(node.func, ast.Name):
+                    raise ValueError("Only simple function calls are allowed")
+                if node.func.id not in safe_locals:
+                    raise ValueError(f"Function {node.func.id} is not allowed")
+                args = [_safe_eval(arg, safe_locals) for arg in node.args]
+                return safe_locals[node.func.id](*args)
+            raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
         def _resolve_fn(task_dict: dict):
             """Resolve a callable from task dict."""
             if "fn" in task_dict:
@@ -150,7 +191,12 @@ def orchestrator_run_dag(
                     "abs": abs,
                     "round": round,
                 }
-                return lambda *_a, **_kw: eval(expr, {"__builtins__": {}}, safe_locals)
+
+                def evaluator(*_a, **_kw):
+                    tree = ast.parse(expr, mode="eval")
+                    return _safe_eval(tree, safe_locals)
+
+                return evaluator
             # Default: identity (return args as-is)
             return lambda *a, **kw: {"args": a, "kwargs": kw}
 


### PR DESCRIPTION
**🚨 Severity:** CRITICAL
**💡 Vulnerability:** The `orchestrator_run_dag` MCP tool in `src/codomyrmex/orchestrator/mcp_tools.py` accepted a `fn_expr` string parameter and evaluated it using Python's native `eval()` function. Even though the original code attempted to sandbox the evaluation by clearing `__builtins__` and explicitly injecting only safe functions into `locals`, this sandbox mechanism in Python is inherently flawed. Attackers can often bypass such restrictions using introspection or built-in object methods to achieve arbitrary remote code execution (RCE).
**🎯 Impact:** Any agent or user passing malformed `fn_expr` strings could execute arbitrary shell commands on the host machine running the orchestrator.
**🔧 Fix:** Replaced the unsafe `eval()` call with a recursive, secure AST evaluator (`_safe_eval`). The new implementation parses the expression into an Abstract Syntax Tree using `ast.parse` and strictly whitelists explicit binary and unary operators, standard constant types, iterables (lists, tuples), and a specific subset of function calls explicitly provided in `safe_locals` (like `len`, `sum`, `max`). By completely avoiding the execution layer of the Python interpreter, the vulnerability is fully eliminated.
**✅ Verification:** Ran the full test suite and targeted tests (`tests/unit/orchestrator/`) successfully, and added a manual standalone script confirming mathematical and whitelisted function calls evaluate correctly while malicious calls (e.g., executing shell commands) are safely rejected via AST node type checking. Logged findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14742047261119664252](https://jules.google.com/task/14742047261119664252) started by @docxology*