### PR TITLE
fix: 🛡️ [CRITICAL] Fix arbitrary code execution in workflow scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@ Duplicate definitions across modules (e.g., repeating the `SecretType` definitio
 
 **Prevention:**
 Use descriptive suffixes or alternatives (e.g., changing `"password"` to `"password_type"`) for model or type definitions. Implement robust CI checks to enforce single-source-of-truth patterns rather than duplicating classes.
+## 2025-02-14 - Arbitrary Code Execution via Restricted Eval Bypass in Workflow Scripts
+**Vulnerability:** The `ScriptExecutor` in `codomyrmex/testing/workflow/executors.py` was using `eval` to process user-provided strings. Even though it restricted builtins via `{"__builtins__": {}}` and only provided `ctx`, attackers could still exploit this using Python object introspection, e.g., traversing `ctx.__class__.__bases__[0].__subclasses__()` to access dangerous built-ins.
+**Learning:** Emptying `__builtins__` is not sufficient to prevent code injection in Python's `eval()`. Without explicitly validating the Abstract Syntax Tree (AST), Python's dynamic object model allows for traversal payloads that recover arbitrary function execution.
+**Prevention:** If an expression-evaluator is necessary without a third-party sandbox, explicitly parse the untrusted string with `ast.parse` and walk the AST to explicitly block disallowed nodes (like access to attributes starting with `_`, and calls to `eval`/`exec`).

--- a/src/codomyrmex/testing/workflow/executors.py
+++ b/src/codomyrmex/testing/workflow/executors.py
@@ -4,6 +4,7 @@ Workflow Testing Executors
 Step executors for workflow assertions, waits, and scripts.
 """
 
+import ast
 import time
 from abc import ABC, abstractmethod
 from typing import Any
@@ -97,9 +98,19 @@ class ScriptExecutor(StepExecutor):
             if callable(script_fn):
                 result = script_fn(context)
             else:
-                # SECURITY: Restricted eval — only 'ctx' is accessible, builtins disabled
+                expr_str = step.config.get("expression", "True")
+
+                # SECURITY: Restricted eval — only 'ctx' is accessible, builtins disabled.
+                # Adding defense-in-depth AST validation to prevent access to dunders and private attributes.
+                tree = ast.parse(expr_str, mode='eval')
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Attribute) and node.attr.startswith('_'):
+                        raise ValueError(f"Access to private attribute '{node.attr}' is not allowed.")
+                    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id in ('eval', 'exec'):
+                        raise ValueError(f"Call to '{node.func.id}' is not allowed.")
+
                 result = eval(
-                    step.config.get("expression", "True"),
+                    expr_str,
                     {"__builtins__": {}},
                     {"ctx": context},
                 )


### PR DESCRIPTION
**What:** The `ScriptExecutor` in `codomyrmex/testing/workflow/executors.py` was vulnerable to sandbox escapes because it relied solely on `{"__builtins__": {}}` while calling `eval()`.
**Risk:** CRITICAL. While built-ins were restricted, an attacker passing a Python string expression could use object introspection on the provided `ctx` object (e.g., `ctx.__class__.__bases__[0].__subclasses__()`) to completely escape the sandbox and achieve arbitrary remote code execution on the host system.
**Solution:** Added defense-in-depth AST validation prior to execution. The expression is parsed into an abstract syntax tree via `ast.parse` and statically analyzed to immediately block execution if any attempt is made to access private/dunder attributes (e.g., `_...`) or call `eval` or `exec`. This reliably defeats the introspection techniques used to bypass restricted evals in Python.

---
*PR created automatically by Jules for task [4662119618688416615](https://jules.google.com/task/4662119618688416615) started by @docxology*