### PR TITLE
feat: 🎨 palette: Add aria attributes to nav-rail toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-12 - Added ARIA attributes to icon-only toggle buttons in React Components
+**Learning:** Found an accessibility issue pattern specific to this app's components, where collapsible parent navigation items used an icon-only `<button>` element without any `aria-label` or `aria-expanded` attributes, which screen readers need to properly announce the button's purpose and state.
+**Action:** Always ensure icon-only interactive elements explicitly provide an `aria-label` (e.g., `aria-label="Toggle "`) and reflect their current state (e.g., `aria-expanded={isExpanded}`) for accessibility.


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `aria-expanded` attributes to the icon-only collapse/expand menu toggle button in the navigation rail parent items.
🎯 **Why**: Previously, the icon-only button had no accessible name or state, meaning screen readers would announce it simply as "button" and fail to inform users whether the menu was collapsed or expanded.
📸 **Before/After**: Visually identical, purely an accessibility change.
♿ **Accessibility**: Provides a clear label ("Toggle [Menu Name]") and its current state via `aria-expanded`.

---
*PR created automatically by Jules for task [11378833739512769948](https://jules.google.com/task/11378833739512769948) started by @docxology*