### PR TITLE
perf: ⚡ Bolt: optimize type mapping in config validation

### DIFF
--- a/src/codomyrmex/config_management/validation/config_validator.py
+++ b/src/codomyrmex/config_management/validation/config_validator.py
@@ -112,6 +112,17 @@ class ConfigValidator:
     required field checking, and detailed error reporting with suggestions.
     """
 
+    # Optimization: Move static type mapping to class level to prevent
+    # repeated dictionary allocation overhead during frequent validation checks.
+    _TYPE_MAP = {
+        "str": str,
+        "int": int,
+        "float": float,
+        "bool": bool,
+        "list": list,
+        "dict": dict,
+    }
+
     def __init__(self, schema: dict[str, ConfigSchema] | None = None):
         """
         Initialize the configuration validator.
@@ -434,20 +445,11 @@ class ConfigValidator:
 
     def _check_type(self, value: Any, expected_type: str) -> bool:
         """Check if value matches expected type."""
-        type_map = {
-            "str": str,
-            "int": int,
-            "float": float,
-            "bool": bool,
-            "list": list,
-            "dict": dict,
-        }
-
         # Handle "any" type - accept everything
         if expected_type == "any":
             return True
 
-        type_class = type_map.get(expected_type)
+        type_class = self._TYPE_MAP.get(expected_type)
         if type_class is not None:
             return isinstance(value, type_class)
 


### PR DESCRIPTION
**What:** 
Moved the inline `type_map` dictionary inside the `ConfigValidator._check_type` method to a static, class-level constant `_TYPE_MAP`.

**Why:** 
The `_check_type` method is called repeatedly during configuration validation (once for every field being checked). Re-instantiating the same mapping dictionary of string names to built-in Python types on every call creates unnecessary memory allocation and function overhead.

**Impact:** 
Eliminates redundant object allocations, resulting in slightly faster execution of configuration validation processes and lower garbage collection overhead during heavily validated configurations.

**Measurement:** 
Verification includes ensuring `pytest tests/unit/config_management/` and full test suites pass successfully. The optimization relies on fundamental Python interpreter behavior where class-level variables are initialized once at import time rather than at invocation time.

---
*PR created automatically by Jules for task [16941299693124837104](https://jules.google.com/task/16941299693124837104) started by @docxology*