### PR TITLE
feat: 🎨 palette: add missing aria-labels to icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-13 - Added aria-labels to terminal, pipeline, and project modal
+**Learning:** Found several icon-only buttons (`variant="ghost"` with `size="icon-*"`) missing accessible names across major UI areas (Terminal toolbar, Pipeline tab, and Project Manager modal). Relying solely on SVG graphics without a `title` or `aria-label` makes these actions invisible to screen reader users.
+**Action:** Next time when working on custom icon-only actions or refactoring buttons with SVG children, I will consistently use `aria-label` or `title` on the `<Button>` component to explicitly communicate its purpose.


### PR DESCRIPTION
💡 What: Added aria-label attributes to icon-only buttons that were lacking descriptive text.
🎯 Why: Enhances accessibility for screen reader users by providing context to what the buttons do, making the UI more intuitive.
📸 Before/After: N/A
♿ Accessibility: Increased a11y support on toolbars, modals, and pipeline tabs.

---
*PR created automatically by Jules for task [5073421243146346225](https://jules.google.com/task/5073421243146346225) started by @docxology*