### PR TITLE
test: 🧪 Add missing test for has_mcp_contract_gap

### DIFF
--- a/tests/unit/system_discovery/test_module_catalog.py
+++ b/tests/unit/system_discovery/test_module_catalog.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import pytest
 from tests.support.repo_paths import PACKAGE_ROOT, REPO_ROOT
 
-from codomyrmex.system_discovery.module_catalog import build_module_catalog
+from codomyrmex.system_discovery.module_catalog import (
+    ModuleCatalogEntry,
+    build_module_catalog,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -39,6 +42,42 @@ def test_catalog_has_no_retired_architecture_entry() -> None:
 def test_mcp_tool_modules_have_specs() -> None:
     catalog = build_module_catalog(_repo_root())
     assert catalog.mcp_tool_modules_missing_specs == ()
+
+
+def test_has_mcp_contract_gap() -> None:
+    def make_entry(*, has_mcp_tools: bool, has_mcp_spec: bool) -> ModuleCatalogEntry:
+        return ModuleCatalogEntry(
+            name="dummy",
+            relative_path="dummy",
+            kind="runtime_module",
+            has_init=True,
+            has_readme=True,
+            has_agents=True,
+            has_spec=True,
+            has_pai=True,
+            has_api_spec=True,
+            has_mcp_tools=has_mcp_tools,
+            has_mcp_spec=has_mcp_spec,
+            has_py_typed=True,
+            has_tests=True,
+            docs_module_exists=True,
+        )
+
+    # Missing spec when tools exist is a gap
+    entry1 = make_entry(has_mcp_tools=True, has_mcp_spec=False)
+    assert entry1.has_mcp_contract_gap is True
+
+    # Has spec when tools exist is not a gap
+    entry2 = make_entry(has_mcp_tools=True, has_mcp_spec=True)
+    assert entry2.has_mcp_contract_gap is False
+
+    # No tools and no spec is not a gap
+    entry3 = make_entry(has_mcp_tools=False, has_mcp_spec=False)
+    assert entry3.has_mcp_contract_gap is False
+
+    # No tools but has spec is not a gap (though perhaps unusual)
+    entry4 = make_entry(has_mcp_tools=False, has_mcp_spec=True)
+    assert entry4.has_mcp_contract_gap is False
 
 
 def test_config_audits_has_api_spec() -> None:


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `has_mcp_contract_gap` property of the `ModuleCatalogEntry` class in `tests/unit/system_discovery/test_module_catalog.py`.
📊 **Coverage:** Exhaustively tests all four combinations of `has_mcp_tools` and `has_mcp_spec` flags.
✨ **Result:** Improved test coverage for the `module_catalog.py` system discovery component.

---
*PR created automatically by Jules for task [4099219281194306016](https://jules.google.com/task/4099219281194306016) started by @docxology*