### PR TITLE
test: 🧪 add test for docs_module_missing in module catalog

### DIFF
--- a/tests/unit/system_discovery/test_module_catalog.py
+++ b/tests/unit/system_discovery/test_module_catalog.py
@@ -57,6 +57,11 @@ def test_docs_modules_have_source_entries() -> None:
     assert catalog.docs_modules_without_source_entries == ()
 
 
+def test_docs_module_missing() -> None:
+    catalog = build_module_catalog(_repo_root())
+    assert catalog.docs_module_missing == ()
+
+
 def test_catalog_to_dict_is_json_ready() -> None:
     data = build_module_catalog(_repo_root()).to_dict()
     assert data["runtime_module_count"] > 0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a missing unit test for the `docs_module_missing` property in `ModuleCatalog` which tracks runtime modules lacking documentation counterparts.

📊 **Coverage:** What scenarios are now tested
A new test `test_docs_module_missing` was added to `tests/unit/system_discovery/test_module_catalog.py`. This test relies on the project's own repository layout to build a real `ModuleCatalog` and verify that the `docs_module_missing` property functions correctly (by evaluating to an empty tuple).

✨ **Result:** The improvement in test coverage
Increased the unit test coverage of the `system_discovery.module_catalog` component, protecting it against regressions when modifications to the documentation validation logic happen in the future.

---
*PR created automatically by Jules for task [10114509795097189481](https://jules.google.com/task/10114509795097189481) started by @docxology*