### PR TITLE
test: 🧪 Add tests for export_capabilities_report

### DIFF
--- a/tests/unit/system_discovery/test_capability_scanner.py
+++ b/tests/unit/system_discovery/test_capability_scanner.py
@@ -145,3 +145,52 @@ CONSTANT = 42
         modules = scanner.scan_all_modules()
         assert isinstance(modules, dict)
         assert len(modules) > 0
+
+    def test_export_capabilities_report_success(self, tmp_path: Path):
+        scanner = CapabilityScanner(project_root=tmp_path)
+        caps = {
+            "test_module": ModuleCapability(
+                name="test_module",
+                path="/src/test_module",
+                docstring="A test module.",
+                functions=[
+                    FunctionCapability(
+                        name="f", signature="f()", docstring="doc", parameters=[], return_annotation="None",
+                        file_path="f.py", line_number=1, is_async=False, is_generator=False, decorators=[],
+                        complexity_score=1
+                    )
+                ],
+                classes=[
+                    ClassCapability(
+                        name="C", docstring="doc", properties=[], class_variables=[], inheritance=[],
+                        file_path="c.py", line_number=1, is_abstract=False, decorators=[], methods=[]
+                    )
+                ],
+                constants={},
+                imports=[],
+                exports=[],
+                file_count=5,
+                line_count=200,
+                last_modified="2026-01-01"
+            )
+        }
+        output = scanner.export_capabilities_report(caps, filename="test.json")
+        assert output == str(tmp_path / "test.json")
+        assert (tmp_path / "test.json").exists()
+
+    def test_export_capabilities_report_default_filename(self, tmp_path: Path):
+        scanner = CapabilityScanner(project_root=tmp_path)
+        output = scanner.export_capabilities_report({})
+        assert output.startswith(str(tmp_path / "codomyrmex_capabilities_"))
+        assert output.endswith(".json")
+        assert Path(output).exists()
+
+    def test_export_capabilities_report_error(self, tmp_path: Path):
+        # Make tmp_path read-only to trigger an Exception
+        read_only_dir = tmp_path / "readonly"
+        read_only_dir.mkdir()
+        read_only_dir.chmod(0o444)
+
+        scanner = CapabilityScanner(project_root=read_only_dir)
+        output = scanner.export_capabilities_report({}, filename="test.json")
+        assert output == ""


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `export_capabilities_report` method in `capability_scanner.py`, which was completely untested.
📊 **Coverage:** Covered the happy path with a specified filename, the happy path with the default generated filename, and the error handling path. To conform with the project's zero-mock testing policy, the error path is simulated using a read-only directory to trigger real file I/O exceptions.
✨ **Result:** Enhanced the test suite coverage, making the capability scanner more robust against future regressions.

---
*PR created automatically by Jules for task [12584312258662412573](https://jules.google.com/task/12584312258662412573) started by @docxology*