### PR TITLE
refactor: 🧹 remove unused FalsificationFinding import

### DIFF
--- a/src/codomyrmex/colony_kernel/mcp_tools.py
+++ b/src/codomyrmex/colony_kernel/mcp_tools.py
@@ -31,7 +31,6 @@ from codomyrmex.colony_kernel.models import (
     AgentTrustProfile,
     ColonySignal,
     DecayRate,
-    FalsificationFinding,
     FalsificationSeverity,
     GateResult,
     PruningCandidate,


### PR DESCRIPTION
🎯 **What:** Removed the unused `FalsificationFinding` import from `src/codomyrmex/colony_kernel/mcp_tools.py`.
💡 **Why:** This improves the code health and maintainability of the codebase by removing dead code. It resolves a linter warning about an unused import.
✅ **Verification:** Verified by checking that `npm test` and `uv run pytest` pass successfully, ensuring no functionality was broken.
✨ **Result:** A cleaner file with no unused imports.

---
*PR created automatically by Jules for task [3589480763974099466](https://jules.google.com/task/3589480763974099466) started by @docxology*