### PR TITLE
fix: 🛡️ [CRITICAL] Fix insecure deserialization in PickleSerializer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,14 @@ Duplicate definitions across modules (e.g., repeating the `SecretType` definitio
 
 **Prevention:**
 Use descriptive suffixes or alternatives (e.g., changing `"password"` to `"password_type"`) for model or type definitions. Implement robust CI checks to enforce single-source-of-truth patterns rather than duplicating classes.
+
+## 2026-03-01 - Fix Insecure Deserialization in Cache PickleSerializer
+
+**Vulnerability:**
+The `PickleSerializer` in `src/codomyrmex/cache/serializers/__init__.py` relied entirely on the standard library `pickle` to deserialize incoming byte payloads. Since `pickle.loads()` can execute arbitrary code encoded in the payload, this permitted remote code execution (RCE) if an attacker could inject or modify cached data.
+
+**Learning:**
+Relying on documented warnings (e.g., "Only use this with trusted data") is insufficient defense against insecure deserialization, especially in generic caching libraries that might inadvertently process untrusted network input. An active mitigation is required even when preserving the core capability.
+
+**Prevention:**
+When the functionality of unsafe deserializers (like `pickle`) is strictly required for preserving complex internal state (e.g., non-JSON serializable objects), implement mandatory HMAC (Hash-based Message Authentication Code) signature wrapping. By prepending a 32-byte cryptographic signature generated using a secret key, the deserializer can verify payload integrity in constant time before invoking the hazardous unpickling operation.

--- a/src/codomyrmex/cache/serializers/__init__.py
+++ b/src/codomyrmex/cache/serializers/__init__.py
@@ -5,7 +5,10 @@ Provides serializers for cache values.
 """
 
 import base64
+import hashlib
+import hmac
 import json
+import os
 import pickle
 import zlib
 from abc import ABC, abstractmethod
@@ -15,6 +18,8 @@ from typing import Any, Optional
 from codomyrmex.logging_monitoring import get_logger
 
 logger = get_logger(__name__)
+
+_PICKLE_SECRET_KEY = os.urandom(32)
 
 
 class CacheSerializer(ABC):
@@ -53,16 +58,37 @@ class PickleSerializer(CacheSerializer):
         for untrusted or network-sourced cache entries.
     """
 
-    def __init__(self, protocol: int = pickle.HIGHEST_PROTOCOL):
+    def __init__(
+        self,
+        protocol: int = pickle.HIGHEST_PROTOCOL,
+        secret_key: bytes | str | None = None,
+    ):
         self.protocol = protocol
+        if secret_key:
+            self.secret_key = (
+                secret_key.encode("utf-8")
+                if isinstance(secret_key, str)
+                else secret_key
+            )
+        else:
+            self.secret_key = _PICKLE_SECRET_KEY
 
     def serialize(self, value: Any) -> bytes:
         """Serialize this object to a portable format."""
-        return pickle.dumps(value, protocol=self.protocol)
+        payload = pickle.dumps(value, protocol=self.protocol)
+        mac = hmac.new(self.secret_key, payload, hashlib.sha256).digest()
+        return mac + payload
 
     def deserialize(self, data: bytes) -> Any:
         """Deserialize from a portable format and return an instance."""
-        return pickle.loads(data)
+        if len(data) < 32:
+            raise ValueError("Invalid payload: too short")
+        mac = data[:32]
+        payload = data[32:]
+        expected_mac = hmac.new(self.secret_key, payload, hashlib.sha256).digest()
+        if not hmac.compare_digest(mac, expected_mac):
+            raise ValueError("Invalid payload: signature mismatch")
+        return pickle.loads(payload)
 
 
 class CompressedSerializer(CacheSerializer):

--- a/tests/unit/cache/test_cache_serializers.py
+++ b/tests/unit/cache/test_cache_serializers.py
@@ -77,6 +77,30 @@ class TestPickleSerializer:
         s = PickleSerializer(protocol=2)
         assert s.protocol == 2
 
+    def test_deserialize_invalid_payload_too_short(self):
+        s = PickleSerializer()
+        with pytest.raises(ValueError, match="Invalid payload: too short"):
+            s.deserialize(b"short")
+
+    def test_deserialize_invalid_payload_signature_mismatch(self):
+        s1 = PickleSerializer(secret_key="key1")
+        s2 = PickleSerializer(secret_key="key2")
+        data = s1.serialize({"key": "val"})
+        with pytest.raises(ValueError, match="Invalid payload: signature mismatch"):
+            s2.deserialize(data)
+
+    def test_custom_secret_key(self):
+        s1 = PickleSerializer(secret_key="my-secret-key")
+        s2 = PickleSerializer(secret_key="my-secret-key")
+        data = s1.serialize({"key": "val"})
+        assert s2.deserialize(data) == {"key": "val"}
+
+    def test_custom_secret_key_bytes(self):
+        s1 = PickleSerializer(secret_key=b"my-secret-key")
+        s2 = PickleSerializer(secret_key=b"my-secret-key")
+        data = s1.serialize({"key": "val"})
+        assert s2.deserialize(data) == {"key": "val"}
+
 
 # ── CompressedSerializer ──────────────────────────────────────────────
 


### PR DESCRIPTION
🎯 What: Fixed insecure deserialization vulnerability (RCE risk) via `pickle` in the Cache component's `PickleSerializer`.
⚠️ Risk: Untrusted payloads could execute arbitrary code when deserialized using `PickleSerializer`.
🛡️ Solution: Added mandatory HMAC-SHA256 signature verification to `PickleSerializer` using a random ephemeral secret key by default, or a user-provided key. This ensures that any data being unpickled is verified to have been serialized by an authorized instance with the same key, mitigating the RCE vulnerability.

---
*PR created automatically by Jules for task [8794416631627744118](https://jules.google.com/task/8794416631627744118) started by @docxology*