### PR TITLE
test: 🧪 Add unit tests for get_default_engine in templating module

### DIFF
--- a/tests/unit/templating/test_init.py
+++ b/tests/unit/templating/test_init.py
@@ -1,0 +1,52 @@
+"""Tests for templating __init__.py."""
+
+import pytest
+import sys
+from importlib import reload
+
+from codomyrmex.templating import get_default_engine
+from codomyrmex.templating.engines.template_engine import TemplateEngine
+
+
+@pytest.mark.unit
+class TestGetDefaultEngine:
+    """Tests for get_default_engine function."""
+
+    @pytest.fixture(autouse=True)
+    def reset_default_engine(self):
+        """Reset the global _default_engine before and after each test."""
+        import codomyrmex.templating as t
+        original = t._default_engine
+        t._default_engine = None
+        yield
+        t._default_engine = original
+
+    def test_get_default_engine_jinja2(self):
+        """Test get_default_engine returns Jinja2 engine by default."""
+        engine = get_default_engine()
+        assert isinstance(engine, TemplateEngine)
+        assert engine.engine == "jinja2"
+
+    def test_get_default_engine_caching(self):
+        """Test get_default_engine caches the engine instance."""
+        engine1 = get_default_engine()
+        engine2 = get_default_engine()
+        assert engine1 is engine2
+
+    def test_get_default_engine_different_type(self):
+        """Test get_default_engine with different engine type creates new instance."""
+        engine1 = get_default_engine("jinja2")
+        # Ensure we reset for the different type request if needed or just get a new one
+        engine2 = get_default_engine("mako")
+        assert engine1 is not engine2
+        assert engine2.engine == "mako"
+
+    def test_get_default_engine_import_error(self, monkeypatch):
+        """Test get_default_engine raises ImportError if TemplateEngine is not available."""
+        import codomyrmex.templating as t
+
+        # Mock TemplateEngine to be None to simulate import failure
+        monkeypatch.setattr(t, "TemplateEngine", None)
+
+        with pytest.raises(ImportError, match="TemplateEngine not available"):
+            get_default_engine()

--- a/tests/unit/templating/test_init.py
+++ b/tests/unit/templating/test_init.py
@@ -1,8 +1,9 @@
 """Tests for templating __init__.py."""
 
-import pytest
 import sys
 from importlib import reload
+
+import pytest
 
 from codomyrmex.templating import get_default_engine
 from codomyrmex.templating.engines.template_engine import TemplateEngine
@@ -16,6 +17,7 @@ class TestGetDefaultEngine:
     def reset_default_engine(self):
         """Reset the global _default_engine before and after each test."""
         import codomyrmex.templating as t
+
         original = t._default_engine
         t._default_engine = None
         yield


### PR DESCRIPTION
🎯 **What:** The testing gap for `get_default_engine` in `src/codomyrmex/templating/__init__.py` has been addressed by introducing `tests/unit/templating/test_init.py`.
📊 **Coverage:** The new tests cover:
- Default `jinja2` engine instantiation.
- Engine instance caching (returns the exact same instance on successive identical calls).
- Cache busting (returns a new instance when a different `engine_type` is requested).
- Error handling (simulates `TemplateEngine` import failure to raise `ImportError`).
✨ **Result:** Test coverage for `get_default_engine` has been substantially improved and verifies correct functionality across various paths, increasing the reliability of the `templating` module.

---
*PR created automatically by Jules for task [18208687712342197249](https://jules.google.com/task/18208687712342197249) started by @docxology*