### PR TITLE
test: 🧪 add tests for default_serializer

### DIFF
--- a/src/codomyrmex/system_discovery/core/discovery_engine.py
+++ b/src/codomyrmex/system_discovery/core/discovery_engine.py
@@ -32,6 +32,13 @@ from .dependency_analyzer import DependencyAnalyzer
 from .health_checker import SystemHealthChecker
 
 
+def default_serializer(obj: Any) -> str:
+    """Default JSON serializer for objects not serializable by default."""
+    if isinstance(obj, (Path, set)):
+        return str(list(obj) if isinstance(obj, set) else obj)
+    return str(obj)
+
+
 @dataclass
 class ModuleCapability:
     """A single discovered capability (function, class, method, or constant) within a module."""
@@ -145,11 +152,6 @@ class SystemDiscovery:
         """
         try:
             inventory = self.scan_system()
-
-            def default_serializer(obj):
-                if isinstance(obj, (Path, set)):
-                    return str(list(obj) if isinstance(obj, set) else obj)
-                return str(obj)
 
             with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(inventory, f, indent=2, default=default_serializer)

--- a/src/codomyrmex/tests/unit/system_discovery/test_discovery_engine.py
+++ b/src/codomyrmex/tests/unit/system_discovery/test_discovery_engine.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+from codomyrmex.system_discovery.core.discovery_engine import SystemDiscovery, default_serializer
+
+def test_default_serializer():
+    assert default_serializer(Path("/tmp/test")) == str(Path("/tmp/test"))
+    # The serializer handles sets by converting to list then stringifying
+    assert default_serializer({1, 2, 3}) == str([1, 2, 3])
+    assert default_serializer(123) == "123"
+    assert default_serializer("test") == "test"
+
+class TestDiscoveryEngine(SystemDiscovery):
+    def scan_system(self):
+        return {
+            "path_obj": Path("/some/path"),
+            "set_obj": {1, 2, 3},
+            "custom_obj": object(),
+        }
+
+def test_export_inventory(tmp_path):
+    engine = TestDiscoveryEngine()
+    output_path = tmp_path / "inventory.json"
+
+    success = engine.export_inventory(output_path)
+
+    assert success is True
+    assert output_path.exists()
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["path_obj"] == str(Path("/some/path"))
+    assert isinstance(data["set_obj"], str)


### PR DESCRIPTION
🎯 **What:** The `default_serializer` logic inside `discovery_engine.py` was implemented as a nested function inside `export_inventory`, making it inaccessible for direct unit testing. This gap is addressed by extracting it into a public module-level function and writing comprehensive tests.
📊 **Coverage:** The new tests cover:
- Serialization of `Path` objects.
- Serialization of `set` objects (converting to lists).
- Fallback serialization of primitives (e.g., strings and integers).
- An integration test verifying that `export_inventory` works correctly end-to-end with the new top-level function.
✨ **Result:** Test coverage and code testability are improved, ensuring regressions are caught if the default serialization logic changes in the future.

---
*PR created automatically by Jules for task [11321447968573459358](https://jules.google.com/task/11321447968573459358) started by @docxology*