### PR TITLE
refactor: 🧹 remove unused SUPPORTED_FORMATS import in frame_extractor.py

### DIFF
--- a/src/codomyrmex/video/extraction/frame_extractor.py
+++ b/src/codomyrmex/video/extraction/frame_extractor.py
@@ -7,7 +7,7 @@ generating thumbnails, and extracting audio from video files.
 import time
 from pathlib import Path
 
-from codomyrmex.video._validation import SUPPORTED_FORMATS, validate_video_path
+from codomyrmex.video._validation import validate_video_path
 from codomyrmex.video.config import get_config
 from codomyrmex.video.exceptions import (
     AudioExtractionError,

--- a/tests/unit/video/test_video.py
+++ b/tests/unit/video/test_video.py
@@ -332,7 +332,7 @@ class TestFrameExtractor:
 
     def test_supported_formats(self) -> None:
         """Test supported format constants."""
-        from codomyrmex.video.extraction.frame_extractor import SUPPORTED_FORMATS
+        from codomyrmex.video._validation import SUPPORTED_FORMATS
 
         assert ".mp4" in SUPPORTED_FORMATS
         assert ".avi" in SUPPORTED_FORMATS

--- a/tests/unit/video/test_video_core.py
+++ b/tests/unit/video/test_video_core.py
@@ -559,7 +559,7 @@ class TestSupportedFormats:
 
     @pytest.mark.unit
     def test_extractor_formats(self) -> None:
-        from codomyrmex.video.extraction.frame_extractor import SUPPORTED_FORMATS
+        from codomyrmex.video._validation import SUPPORTED_FORMATS
 
         for ext in (".mp4", ".avi", ".mov"):
             assert ext in SUPPORTED_FORMATS


### PR DESCRIPTION
🎯 **What:** Removed the unused `SUPPORTED_FORMATS` import from `src/codomyrmex/video/extraction/frame_extractor.py` and updated `tests/unit/video/test_video.py` and `tests/unit/video/test_video_core.py` to import `SUPPORTED_FORMATS` directly from its true source (`codomyrmex.video._validation`).

💡 **Why:** This resolves a linter warning about an unused import, improving the maintainability and readability of the codebase by avoiding unnecessary imports. Updating the test files ensures that they test the correct module (`_validation`) directly rather than relying on an indirect import through `frame_extractor.py`.

✅ **Verification:** Verified the fix by running `uv run ruff check` to ensure the linter warning is resolved. Also ran the test suite using `uv run pytest tests/unit/video/` and full test suite to confirm that no functionality is broken and all tests pass.

✨ **Result:** The code health issue is successfully resolved without changing the core behavior.

---
*PR created automatically by Jules for task [7215752290651493041](https://jules.google.com/task/7215752290651493041) started by @docxology*