### PR TITLE
fix: 🎨 Palette: Add missing ARIA labels to header buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-14 - Missing ARIA Labels on Icon Buttons
+**Learning:** The application has a recurring accessibility pattern where icon-only buttons (such as those in the header and theme selector) lack `aria-label` attributes, making them inaccessible to screen readers despite having `title` attributes or tooltip equivalents.
+**Action:** Always verify that icon-only `<Button>` components explicitly include an `aria-label` during development or code review.


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to the theme selector, mobile search, and notifications buttons in the header navigation. Also added a missing `title` attribute to the notifications button.
🎯 **Why:** Icon-only buttons without accessible labels cannot be interpreted by screen readers, making these core navigation features inaccessible to users relying on assistive technologies.
📸 **Before/After:** Not applicable (visually identical).
♿ **Accessibility:** Screen reader users can now successfully identify and use the search, notifications, and theme selector functions.

---
*PR created automatically by Jules for task [3418651201784092494](https://jules.google.com/task/3418651201784092494) started by @docxology*