### PR TITLE
perf: ⚡ Bolt: Optimize regex compilation in template engines

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 
 **Learning:** Recreating static dictionaries on every function call (e.g. `type_map = {"int": int, ...}` inside `deserialize`) adds significant overhead in frequently called code paths.
 **Action:** Move static mapping dictionaries to class-level or module-level constants (e.g. `_TYPE_MAP`) to initialize them once and eliminate per-call allocation overhead.
+## 2026-07-22 - Pre-compile Regex in Hot Paths
+**Learning:** Compiling regular expressions via `re.compile()` inside frequently called functions (like template rendering methods) or `__init__` methods creates unnecessary overhead and slows down performance. Python's `re` module caches some patterns, but compiling them at the module level is measurably faster.
+**Action:** Define regular expressions as module-level constants (e.g., `_VAR_PATTERN = re.compile(...)`) instead of recompiling them on every method call or object instantiation.

--- a/src/codomyrmex/templating/engines/jinja2_like.py
+++ b/src/codomyrmex/templating/engines/jinja2_like.py
@@ -12,6 +12,16 @@ from .base import TemplateEngine
 logger = get_logger(__name__)
 
 
+_VARIABLES_PATTERN = re.compile(r"\{\{\s*(.+?)\s*\}\}")
+_FOR_LOOP_PATTERN = re.compile(
+    r"\{%\s*for\s+(\w+)\s+in\s+(.+?)\s*%\}(.+?)\{%\s*endfor\s*%\}", re.DOTALL
+)
+_IF_BLOCK_PATTERN = re.compile(
+    r"\{%\s*if\s+(.+?)\s*%\}(.+?)(?:\{%\s*else\s*%\}(.+?))?\{%\s*endif\s*%\}",
+    re.DOTALL,
+)
+
+
 class Jinja2LikeEngine(TemplateEngine):
     """Enhanced template engine with control structures."""
 
@@ -123,7 +133,6 @@ class Jinja2LikeEngine(TemplateEngine):
 
     def _process_variables(self, template: str, context: dict[str, Any]) -> str:
         """Process {{ variable }} expressions."""
-        pattern = re.compile(r"\{\{\s*(.+?)\s*\}\}")
 
         def replace(match):
             value = self._parse_expression(match.group(1), context)
@@ -134,13 +143,10 @@ class Jinja2LikeEngine(TemplateEngine):
                 result = html.escape(result)
             return result
 
-        return pattern.sub(replace, template)
+        return _VARIABLES_PATTERN.sub(replace, template)
 
     def _process_for_loops(self, template: str, context: dict[str, Any]) -> str:
         """Process {% for item in items %} blocks."""
-        pattern = re.compile(
-            r"\{%\s*for\s+(\w+)\s+in\s+(.+?)\s*%\}(.+?)\{%\s*endfor\s*%\}", re.DOTALL
-        )
 
         def replace(match):
             var_name = match.group(1)
@@ -165,8 +171,8 @@ class Jinja2LikeEngine(TemplateEngine):
 
             return "".join(result)
 
-        while pattern.search(template):
-            template = pattern.sub(replace, template)
+        while _FOR_LOOP_PATTERN.search(template):
+            template = _FOR_LOOP_PATTERN.sub(replace, template)
 
         return template
 
@@ -207,10 +213,6 @@ class Jinja2LikeEngine(TemplateEngine):
 
     def _process_if_blocks(self, template: str, context: dict[str, Any]) -> str:
         """Process {% if condition %} / {% else %} / {% endif %} blocks."""
-        pattern = re.compile(
-            r"\{%\s*if\s+(.+?)\s*%\}(.+?)(?:\{%\s*else\s*%\}(.+?))?\{%\s*endif\s*%\}",
-            re.DOTALL,
-        )
 
         def replace(match):
             condition = match.group(1)
@@ -221,8 +223,8 @@ class Jinja2LikeEngine(TemplateEngine):
                 return self.render(true_block, context)
             return self.render(false_block, context)
 
-        while pattern.search(template):
-            template = pattern.sub(replace, template)
+        while _IF_BLOCK_PATTERN.search(template):
+            template = _IF_BLOCK_PATTERN.sub(replace, template)
 
         return template
 

--- a/src/codomyrmex/templating/engines/mustache.py
+++ b/src/codomyrmex/templating/engines/mustache.py
@@ -6,12 +6,16 @@ from typing import Any
 
 from .base import TemplateEngine
 
+_VAR_PATTERN = re.compile(r"\{\{([#^/]?)(.+?)\}\}")
+_SECTION_PATTERN = re.compile(r"\{\{([#^])(.+?)\}\}(.*?)\{\{/\2\}\}", re.DOTALL)
+_EXPRESSION_PATTERN = re.compile(r"\{\{([^#^/].+?)\}\}")
+
 
 class MustacheEngine(TemplateEngine):
     """Mustache-style logic-less templates."""
 
     def __init__(self):
-        self._var_pattern = re.compile(r"\{\{([#^/]?)(.+?)\}\}")
+        self._var_pattern = _VAR_PATTERN
 
     def render(self, template: str, context: dict[str, Any]) -> str:
         """Render a Mustache template."""
@@ -59,7 +63,6 @@ class MustacheEngine(TemplateEngine):
 
     def _process_sections(self, template: str, context: dict[str, Any]) -> str:
         """Process {{#section}} and {{^section}} blocks."""
-        section_pattern = re.compile(r"\{\{([#^])(.+?)\}\}(.*?)\{\{/\2\}\}", re.DOTALL)
 
         def replace(match):
             section_type = match.group(1)
@@ -75,14 +78,13 @@ class MustacheEngine(TemplateEngine):
             # Inverted section
             return "" if value else self._render_internal(content, context)
 
-        while section_pattern.search(template):
-            template = section_pattern.sub(replace, template)
+        while _SECTION_PATTERN.search(template):
+            template = _SECTION_PATTERN.sub(replace, template)
 
         return template
 
     def _process_variables(self, template: str, context: dict[str, Any]) -> str:
         """Process {{variable}} expressions with optional triple-mustache or & unescaped."""
-        pattern = re.compile(r"\{\{([^#^/].+?)\}\}")
 
         def replace(match):
             name = match.group(1).strip()
@@ -100,7 +102,7 @@ class MustacheEngine(TemplateEngine):
                 return ""
             return html.escape(str(value))
 
-        return pattern.sub(replace, template)
+        return _EXPRESSION_PATTERN.sub(replace, template)
 
     def render_file(self, path: str, context: dict[str, Any]) -> str:
         """Render a template file."""


### PR DESCRIPTION
💡 What: Moved regular expression compilations out of `_process_variables`, `_process_for_loops`, `_process_if_blocks` in `jinja2_like.py`, and out of `__init__`, `_process_sections`, `_process_variables` in `mustache.py` into module-level constants.
🎯 Why: To prevent the repeated allocation and compilation overhead of `re.compile()` on every template rendering call.
📊 Impact: Reduces template processing overhead, improving performance across applications relying on template generation.
🔬 Measurement: Execute `uv run pytest tests/unit/templating/` and `uv run pytest` to ensure functionality is preserved.

---
*PR created automatically by Jules for task [5340883650826603103](https://jules.google.com/task/5340883650826603103) started by @docxology*